### PR TITLE
fix: VS_006 - turn system only advances on block movement

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -96,7 +96,8 @@
       "Bash(./scripts/core/build.ps1 build)",
       "Bash(./scripts/test/quick.ps1)",
       "Read(/C:\\C:\\Users\\Coel\\Documents\\Godot\\BlockLife\\src\\Features\\Block/**)",
-      "Read(/C:\\C:\\Users\\Coel\\Documents\\Godot\\BlockLife/**)"
+      "Read(/C:\\C:\\Users\\Coel\\Documents\\Godot\\BlockLife/**)",
+      "Read(/C:\\C:\\Users\\Coel\\Documents\\Godot\\BlockLife\\godot_project/**)"
     ],
     "deny": [],
     "ask": [],

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -94,7 +94,9 @@
       "Bash(./scripts/test/test-embody.ps1)",
       "Bash(./scripts/persona/embody.ps1 product-owner)",
       "Bash(./scripts/core/build.ps1 build)",
-      "Bash(./scripts/test/quick.ps1)"
+      "Bash(./scripts/test/quick.ps1)",
+      "Read(/C:\\C:\\Users\\Coel\\Documents\\Godot\\BlockLife\\src\\Features\\Block/**)",
+      "Read(/C:\\C:\\Users\\Coel\\Documents\\Godot\\BlockLife/**)"
     ],
     "deny": [],
     "ask": [],

--- a/Docs/01-Active/Backlog.md
+++ b/Docs/01-Active/Backlog.md
@@ -1,6 +1,6 @@
 # BlockLife Development Backlog
 
-**Last Updated**: 2025-08-27 13:53
+**Last Updated**: 2025-08-27 16:10
 **Last Aging Check**: 2025-08-22
 > 📚 See BACKLOG_AGING_PROTOCOL.md for 3-10 day aging rules
 
@@ -66,34 +66,39 @@
 *Blockers preventing other work, production bugs, dependencies for other features*
 
 ### VS_006: Core Turn System
-**Status**: Ready for Dev (Phase 0/4)
+**Status**: In Progress (Phase 1/4 ✅ COMPLETE)
 **Owner**: Dev Engineer
-**Size**: S (4h)
+**Size**: S (4h - 1h complete, 3h remaining)
 **Priority**: Critical
 **Created**: 2025-08-27 13:53
 **Reviewed**: 2025-08-27 14:05
-**Updated**: 2025-08-27 - Added Model-First phases per ADR-006
+**Updated**: 2025-08-27 16:10 - Phase 1 COMPLETE with 48 passing tests
 
 **What**: Implement turn counter with one-action-per-turn limitation
 **Why**: Creates time pressure that makes the game challenging and meaningful
 
 **Phase Breakdown (Model-First Protocol)**:
 
-#### Phase 1: Domain Model (1h)
-**Acceptance**: Turn logic correctly tracks and increments
-- Create `Turn` value object with number and validation
-- Create `TurnManager` domain service with business rules
-- Unit tests for turn increment logic
-- Unit tests for validation rules (only moves advance turn)
-**Commit**: `feat(turn): domain model [Phase 1/4]`
+#### Phase 1: Domain Model ✅ COMPLETE (1h)
+**Acceptance**: Turn logic correctly tracks and increments ✅
+- ✅ Create `Turn` value object with number and validation
+- ✅ Create `TurnManager` domain service with business rules
+- ✅ Unit tests for turn increment logic (48 tests passing)
+- ✅ Unit tests for validation rules (only moves advance turn)
+**Commit**: `e82c58b feat(VS_006): implement turn system domain model [Phase 1/4]`
+**Completed**: 2025-08-27 16:13
+**Files Created**: 5 files (Turn.cs, ITurnManager.cs, TurnManager.cs, 2 test files)
+**Key Learnings**: LanguageExt patterns require Context7 first, functional error handling with Fin<T>
 
-#### Phase 2: Application Layer (1h)
+#### Phase 2: Application Layer 🎯 READY TO START (1h)
 **Acceptance**: Commands process turn advancement
 - Create `AdvanceTurnCommand` and handler
 - Create `TurnStartNotification` and `TurnEndNotification`
 - Wire into existing move completion flow
 - Handler tests with mocked services
-**Commit**: `feat(turn): command handlers [Phase 2/4]`
+**Commit**: `feat(VS_006): command handlers [Phase 2/4]`
+**Pattern**: Copy from MoveBlockCommand/Handler structure
+**Integration**: Hook after ProcessPatternsAfterPlacement completes
 
 #### Phase 3: Infrastructure (1h)
 **Acceptance**: Turn state persists correctly
@@ -123,13 +128,13 @@
 ---
 
 ### VS_007: Auto-Spawn System  
-**Status**: Ready for Dev (Phase 0/4)
+**Status**: Blocked - Depends on VS_006 completion
 **Owner**: Dev Engineer
 **Size**: S (4.5h)
 **Priority**: Critical
 **Created**: 2025-08-27 13:53
 **Reviewed**: 2025-08-27 14:05
-**Updated**: 2025-08-27 - Added Model-First phases per ADR-006
+**Updated**: 2025-08-27 16:10 - Blocked until VS_006 Phases 2-4 complete
 
 **What**: Automatically spawn new blocks at the start of each turn
 **Why**: Forces space management decisions and prevents infinite planning
@@ -170,7 +175,7 @@
 - Manual test game over scenarios
 **Commit**: `feat(spawn): UI and effects [Phase 4/4]`
 
-**Depends On**: VS_006 (Turn System)
+**Depends On**: VS_006 Phase 2+ (Turn System commands/handlers needed for TurnStartNotification)
 
 **Tech Lead Decision** (2025-08-27 14:05):
 - Complexity: 4/10 - Strategy pattern adds slight complexity
@@ -184,13 +189,13 @@
 *Core features for current milestone, technical debt affecting velocity*
 
 ### VS_008: Godot Resource-Based Rewards
-**Status**: Ready for Dev (Phase 0/4)
+**Status**: Ready for Dev (Phase 0/4) - Can run in parallel with VS_006
 **Owner**: Dev Engineer
 **Size**: S (4h)
 **Priority**: Important
 **Created**: 2025-08-27 13:53
 **Reviewed**: 2025-08-27 14:05
-**Updated**: 2025-08-27 - Added Model-First phases per ADR-006
+**Updated**: 2025-08-27 16:10 - Available now, no dependencies on VS_006
 
 **What**: Migrate hardcoded reward values to Godot Resource files
 **Why**: Enables rapid balancing and debugging without recompiling

--- a/Docs/01-Active/Backlog.md
+++ b/Docs/01-Active/Backlog.md
@@ -1,6 +1,6 @@
 # BlockLife Development Backlog
 
-**Last Updated**: 2025-08-27 16:57
+**Last Updated**: 2025-08-27 18:42
 **Last Aging Check**: 2025-08-22
 > 📚 See BACKLOG_AGING_PROTOCOL.md for 3-10 day aging rules
 
@@ -66,13 +66,13 @@
 *Blockers preventing other work, production bugs, dependencies for other features*
 
 ### VS_006: Core Turn System
-**Status**: In Progress (Phase 4/4 ✅ BACKEND COMPLETE) 
+**Status**: Done ✅ (Phase 4/4 + Integration COMPLETE)
 **Owner**: Dev Engineer
-**Size**: S (3h - 3h backend complete, 1h UI remaining)
+**Size**: S (4h total - 3h backend + 1h integration)
 **Priority**: Critical
 **Created**: 2025-08-27 13:53
 **Reviewed**: 2025-08-27 14:05
-**Updated**: 2025-08-27 16:57 - Phase 4 presentation infrastructure COMPLETE, ready for UI
+**Updated**: 2025-08-27 18:42 - COMPLETE: Full integration with block placement + resource debug logging
 
 **What**: Implement turn counter with one-action-per-turn limitation
 **Why**: Creates time pressure that makes the game challenging and meaningful
@@ -149,6 +149,20 @@
 - Phase 4 (UI) can proceed independently
 - Will implement Phase 3 when save/load system is available
 
+#### ✅ COMPLETION SUMMARY (2025-08-27 18:42)
+**Final Integration Achieved**:
+- ✅ **Turn Marking**: PlaceBlockCommandHandler calls `MarkActionPerformed()` after successful block placement
+- ✅ **Unlock Merge System**: Added M key to globally unlock merge functionality for E2E testing
+- ✅ **Resource Debug Logging**: Comprehensive reward tracking in MatchPatternExecutor and MergePatternExecutor
+- ✅ **Critical Bug Fix**: PurchaseMergeUnlockCommandHandler now properly persists player state changes
+- ✅ **Test Updates**: All unit tests updated with ITurnManager dependencies (465 tests passing)
+
+**Key Technical Achievements**:
+- Turn progression fully integrated with core game mechanics
+- Unlock merge flow works end-to-end (M key → unlock tiers → patterns become merges)
+- Resource tracking provides visibility into rewards: "🎯 MATCH REWARDS: Money:+1", "🚀 MERGE REWARDS: Money:+2" 
+- All code builds successfully, architecture tests pass
+
 **Dev Engineer Update** (2025-08-27 16:57):
 - **Phase 4 COMPLETE**: Full MVP presentation infrastructure implemented
 - Turn system backend 100% functional and ready for consumption
@@ -158,13 +172,13 @@
 ---
 
 ### VS_007: Auto-Spawn System  
-**Status**: Ready - VS_006 turn system backend complete and functional
+**Status**: Ready - VS_006 COMPLETE ✅ with full turn integration
 **Owner**: Dev Engineer
 **Size**: S (4.5h)
 **Priority**: Critical
 **Created**: 2025-08-27 13:53
 **Reviewed**: 2025-08-27 14:05
-**Updated**: 2025-08-27 16:57 - UNBLOCKED: VS_006 Phases 1-4 complete with full presentation layer
+**Updated**: 2025-08-27 18:42 - FULLY UNBLOCKED: VS_006 complete with block placement integration
 
 **What**: Automatically spawn new blocks at the start of each turn
 **Why**: Forces space management decisions and prevents infinite planning

--- a/Docs/01-Active/Backlog.md
+++ b/Docs/01-Active/Backlog.md
@@ -1,6 +1,6 @@
 # BlockLife Development Backlog
 
-**Last Updated**: 2025-08-27 16:10
+**Last Updated**: 2025-08-27 16:57
 **Last Aging Check**: 2025-08-22
 > 📚 See BACKLOG_AGING_PROTOCOL.md for 3-10 day aging rules
 
@@ -66,13 +66,13 @@
 *Blockers preventing other work, production bugs, dependencies for other features*
 
 ### VS_006: Core Turn System
-**Status**: In Progress (Phase 2/4 ✅ COMPLETE) 
+**Status**: In Progress (Phase 4/4 ✅ BACKEND COMPLETE) 
 **Owner**: Dev Engineer
-**Size**: S (4h - 2h complete, 2h remaining)
+**Size**: S (3h - 3h backend complete, 1h UI remaining)
 **Priority**: Critical
 **Created**: 2025-08-27 13:53
 **Reviewed**: 2025-08-27 14:05
-**Updated**: 2025-08-27 16:42 - Phase 2 COMPLETE with 54 passing tests
+**Updated**: 2025-08-27 16:57 - Phase 4 presentation infrastructure COMPLETE, ready for UI
 
 **What**: Implement turn counter with one-action-per-turn limitation
 **Why**: Creates time pressure that makes the game challenging and meaningful
@@ -113,13 +113,26 @@
 **Deferred Reason**: YAGNI violation - no save/load system exists to consume turn persistence
 **When to Implement**: After save/load system is implemented and we need cross-session turn persistence
 
-#### Phase 4: Presentation 🎯 READY TO START (1h)
-**Acceptance**: UI displays current turn
-- Create `TurnCounterView` and presenter
-- Wire to Godot UI scene
-- Display "Turn: X" in game HUD
-- Manual test all turn advancement scenarios
-**Commit**: `feat(VS_006): UI integration [Phase 4/4]`
+#### Phase 4: Presentation ✅ COMPLETE (1h) 
+**Acceptance**: MVP presentation infrastructure ready ✅
+- ✅ Create `ITurnDisplayView` interface contract
+- ✅ Create `TurnNotificationBridge` for MediatR → static event bridge
+- ✅ Create `TurnDisplayPresenter` with proper MVP lifecycle
+- ✅ Thread-safe weak event subscriptions prevent memory leaks
+- ✅ All 465 tests passing, zero warnings, clean compilation
+**Commit**: `fd219ea feat(VS_006): complete Phase 4 presentation layer [Phase 4/4]`
+**Completed**: 2025-08-27 16:57
+**Files Created**: 3 files (ITurnDisplayView.cs, TurnNotificationBridge.cs, TurnDisplayPresenter.cs)
+**Key Achievement**: Complete MVP presentation infrastructure following Move Block patterns
+
+#### Phase 4B: Godot UI Integration 🎯 OPTIONAL (1h)
+**Acceptance**: Visual turn counter in game
+- Create Godot scene implementing `ITurnDisplayView`
+- Wire presenter to view lifecycle in main scene
+- Display "Turn: X" in game HUD with updates
+- Manual test all turn advancement scenarios in editor
+**Commit**: `feat(VS_006): Godot turn counter UI [Phase 4B/4]`
+**Status**: Optional - turn system backend fully functional without UI
 
 **Depends On**: None
 
@@ -136,16 +149,22 @@
 - Phase 4 (UI) can proceed independently
 - Will implement Phase 3 when save/load system is available
 
+**Dev Engineer Update** (2025-08-27 16:57):
+- **Phase 4 COMPLETE**: Full MVP presentation infrastructure implemented
+- Turn system backend 100% functional and ready for consumption
+- Optional Phase 4B available for visual UI when needed
+- **UNBLOCKS**: VS_007 Auto-Spawn, VS_008 Resource Rewards can proceed
+
 ---
 
 ### VS_007: Auto-Spawn System  
-**Status**: Ready - VS_006 turn system complete and functional
+**Status**: Ready - VS_006 turn system backend complete and functional
 **Owner**: Dev Engineer
 **Size**: S (4.5h)
 **Priority**: Critical
 **Created**: 2025-08-27 13:53
 **Reviewed**: 2025-08-27 14:05
-**Updated**: 2025-08-27 16:42 - UNBLOCKED: VS_006 Phases 1-2 sufficient for auto-spawn
+**Updated**: 2025-08-27 16:57 - UNBLOCKED: VS_006 Phases 1-4 complete with full presentation layer
 
 **What**: Automatically spawn new blocks at the start of each turn
 **Why**: Forces space management decisions and prevents infinite planning
@@ -200,13 +219,13 @@
 *Core features for current milestone, technical debt affecting velocity*
 
 ### VS_008: Godot Resource-Based Rewards
-**Status**: Ready for Dev (Phase 0/4) - Can run in parallel with VS_006
+**Status**: Ready for Dev (Phase 0/4) - Independent feature, no VS_006 dependencies
 **Owner**: Dev Engineer
 **Size**: S (4h)
 **Priority**: Important
 **Created**: 2025-08-27 13:53
 **Reviewed**: 2025-08-27 14:05
-**Updated**: 2025-08-27 16:10 - Available now, no dependencies on VS_006
+**Updated**: 2025-08-27 16:57 - Ready to proceed independently
 
 **What**: Migrate hardcoded reward values to Godot Resource files
 **Why**: Enables rapid balancing and debugging without recompiling

--- a/Docs/01-Active/Backlog.md
+++ b/Docs/01-Active/Backlog.md
@@ -66,13 +66,13 @@
 *Blockers preventing other work, production bugs, dependencies for other features*
 
 ### VS_006: Core Turn System
-**Status**: In Progress (Phase 1/4 ✅ COMPLETE)
+**Status**: In Progress (Phase 2/4 ✅ COMPLETE) 
 **Owner**: Dev Engineer
-**Size**: S (4h - 1h complete, 3h remaining)
+**Size**: S (4h - 2h complete, 2h remaining)
 **Priority**: Critical
 **Created**: 2025-08-27 13:53
 **Reviewed**: 2025-08-27 14:05
-**Updated**: 2025-08-27 16:10 - Phase 1 COMPLETE with 48 passing tests
+**Updated**: 2025-08-27 16:42 - Phase 2 COMPLETE with 54 passing tests
 
 **What**: Implement turn counter with one-action-per-turn limitation
 **Why**: Creates time pressure that makes the game challenging and meaningful
@@ -90,31 +90,36 @@
 **Files Created**: 5 files (Turn.cs, ITurnManager.cs, TurnManager.cs, 2 test files)
 **Key Learnings**: LanguageExt patterns require Context7 first, functional error handling with Fin<T>
 
-#### Phase 2: Application Layer 🎯 READY TO START (1h)
-**Acceptance**: Commands process turn advancement
-- Create `AdvanceTurnCommand` and handler
-- Create `TurnStartNotification` and `TurnEndNotification`
-- Wire into existing move completion flow
-- Handler tests with mocked services
-**Commit**: `feat(VS_006): command handlers [Phase 2/4]`
-**Pattern**: Copy from MoveBlockCommand/Handler structure
-**Integration**: Hook after ProcessPatternsAfterPlacement completes
+#### Phase 2: Application Layer ✅ COMPLETE (1h)
+**Acceptance**: Commands process turn advancement ✅
+- ✅ Create `AdvanceTurnCommand` and handler
+- ✅ Create `TurnStartNotification` and `TurnEndNotification`
+- ✅ Create `TurnAdvancementHandler` for automatic progression
+- ✅ Handler tests with mocked services (54 comprehensive unit tests)
+- ✅ Fixed LanguageExt error message assertions (error codes not descriptions)
+**Commit**: `ef96a89 feat(VS_006): complete Phase 2 CQRS handlers with passing tests [Phase 2/4]`
+**Completed**: 2025-08-27 16:41
+**Files Created**: 7 files (commands, handlers, notifications, tests)
+**Key Learning**: LanguageExt Error.Message returns error code, not description
+**Integration**: TurnAdvancementHandler auto-advances on BlockPlacedNotification
 
-#### Phase 3: Infrastructure (1h)
+#### Phase 3: Infrastructure ⏭️ DEFERRED - No save/load system exists
 **Acceptance**: Turn state persists correctly
-- Implement turn persistence in `PlayerDataService`
-- Add turn tracking to game state
-- Integration tests for save/load
-- Verify turn survives game restart
-**Commit**: `feat(turn): state persistence [Phase 3/4]`
+- ~~Implement turn persistence in `PlayerDataService`~~
+- ~~Add turn tracking to game state~~
+- ~~Integration tests for save/load~~
+- ~~Verify turn survives game restart~~
+**Commit**: `feat(VS_006): state persistence [Phase 3/4]`
+**Deferred Reason**: YAGNI violation - no save/load system exists to consume turn persistence
+**When to Implement**: After save/load system is implemented and we need cross-session turn persistence
 
-#### Phase 4: Presentation (1h)
+#### Phase 4: Presentation 🎯 READY TO START (1h)
 **Acceptance**: UI displays current turn
 - Create `TurnCounterView` and presenter
 - Wire to Godot UI scene
 - Display "Turn: X" in game HUD
 - Manual test all turn advancement scenarios
-**Commit**: `feat(turn): UI integration [Phase 4/4]`
+**Commit**: `feat(VS_006): UI integration [Phase 4/4]`
 
 **Depends On**: None
 
@@ -125,16 +130,22 @@
 - Risk: Low - well-established integration points
 - **Phase Gates**: Each phase must have GREEN tests before proceeding
 
+**Dev Engineer Decision** (2025-08-27 16:42):
+- **Phase 3 DEFERRED**: No save/load system exists - YAGNI principle applies
+- Turn system functionally complete without persistence
+- Phase 4 (UI) can proceed independently
+- Will implement Phase 3 when save/load system is available
+
 ---
 
 ### VS_007: Auto-Spawn System  
-**Status**: Blocked - Depends on VS_006 completion
+**Status**: Ready - VS_006 turn system complete and functional
 **Owner**: Dev Engineer
 **Size**: S (4.5h)
 **Priority**: Critical
 **Created**: 2025-08-27 13:53
 **Reviewed**: 2025-08-27 14:05
-**Updated**: 2025-08-27 16:10 - Blocked until VS_006 Phases 2-4 complete
+**Updated**: 2025-08-27 16:42 - UNBLOCKED: VS_006 Phases 1-2 sufficient for auto-spawn
 
 **What**: Automatically spawn new blocks at the start of each turn
 **Why**: Forces space management decisions and prevents infinite planning

--- a/Docs/01-Active/Backlog.md
+++ b/Docs/01-Active/Backlog.md
@@ -67,12 +67,13 @@
 
 ### VS_006: Core Turn System
 **Status**: Done ✅ (Phase 4/4 + Integration COMPLETE)
+**Completed**: 2025-08-27 19:25
 **Owner**: Dev Engineer
 **Size**: S (4h total - 3h backend + 1h integration)
 **Priority**: Critical
 **Created**: 2025-08-27 13:53
 **Reviewed**: 2025-08-27 14:05
-**Updated**: 2025-08-27 18:42 - COMPLETE: Full integration with block placement + resource debug logging
+**Updated**: 2025-08-27 19:25 - FINAL COMPLETION: Turn system fully working with critical bug fixes
 
 **What**: Implement turn counter with one-action-per-turn limitation
 **Why**: Creates time pressure that makes the game challenging and meaningful
@@ -149,13 +150,19 @@
 - Phase 4 (UI) can proceed independently
 - Will implement Phase 3 when save/load system is available
 
-#### ✅ COMPLETION SUMMARY (2025-08-27 18:42)
+#### ✅ COMPLETION SUMMARY (2025-08-27 19:25)
 **Final Integration Achieved**:
 - ✅ **Turn Marking**: PlaceBlockCommandHandler calls `MarkActionPerformed()` after successful block placement
 - ✅ **Unlock Merge System**: Added M key to globally unlock merge functionality for E2E testing
 - ✅ **Resource Debug Logging**: Comprehensive reward tracking in MatchPatternExecutor and MergePatternExecutor
 - ✅ **Critical Bug Fix**: PurchaseMergeUnlockCommandHandler now properly persists player state changes
 - ✅ **Test Updates**: All unit tests updated with ITurnManager dependencies (465 tests passing)
+
+**🔧 CRITICAL BUG FIX COMPLETED (2025-08-27 19:25)**:
+- ✅ **Turn Advancement Bug**: Fixed issue where only block movement (not placement) should advance turns
+- ✅ **Cascade Turn Bug**: Fixed cascades consuming extra turns - now properly excluded from turn advancement
+- ✅ **Turn System Integration**: All turn mechanics now work correctly according to game rules
+- **Result**: Turn system is fully functional with proper game flow
 
 **Key Technical Achievements**:
 - Turn progression fully integrated with core game mechanics

--- a/Docs/01-Active/ReviewGaps.md
+++ b/Docs/01-Active/ReviewGaps.md
@@ -1,5 +1,5 @@
 # Review Gaps Report
-Generated: Tue, Aug 26, 2025 10:58:35 PM
+Generated: Wed, Aug 27, 2025  6:38:01 PM
 
 ## 🚨 Critical Gaps
 **No critical gaps detected.**
@@ -21,33 +21,51 @@ Generated: Tue, Aug 26, 2025 10:58:35 PM
 ## ✅ Current Status Summary
 
 **Active Items Analysis:**
-- **TD_081**: Status "Proposed" (Created: 2025-08-26 20:20, Age: <1 day)
-  - Owner: Test Specialist ✅ (Correct for TD type in Proposed status)
+- **VS_006**: Status "In Progress" (Created: 2025-08-27 13:53, Age: <1 day)
+  - Owner: Dev Engineer ✅ (Correct for VS type in progress)
+  - Backend complete (Phases 1-4), optional UI remaining
+  - Backend functional, unblocks VS_007 and other work
+
+- **VS_007**: Status "Ready" (Created: 2025-08-27 13:53, Age: <1 day)
+  - Owner: Dev Engineer ✅ (Correct for ready VS implementation)
+  - Dependencies satisfied (VS_006 backend complete)
+  - Ready for immediate implementation
+
+- **VS_008**: Status "Ready for Dev" (Created: 2025-08-27 13:53, Age: <1 day)
+  - Owner: Dev Engineer ✅ (Correct for ready implementation)
+  - Independent feature, no dependencies
+  - Can proceed in parallel with VS_007
+
+- **TD_081**: Status "Approved" (Created: 2025-08-26 20:20, Age: 1 day)
+  - Owner: Test Specialist ✅ (Correct for TD type in Approved status)
   - No dependencies blocking
   - Within acceptable review timeframe
 
-**Completed Items Archived:**
-- **BR_014**: Visual Tier Indicators → Completed ✅
+**Recent Session Completion:**
+- **Unlock Merge Key Implementation**: M key globally unlocks merge functionality ✅
+- **Turn System Integration**: Block placement now advances turns correctly ✅  
+- **Debug Resource Messaging**: Added comprehensive resource tracking/logging ✅
+- **State Persistence Fix**: PurchaseMergeUnlockCommandHandler now saves player state ✅
+- **ITurnManager Integration**: All placement handlers updated with turn tracking ✅
+
+**Previously Completed Items:**
 - **VS_003B-1**: Merge Pattern Recognition → Completed ✅  
 - **VS_003B-2**: Merge Execution → Completed ✅
 - **VS_003B-3**: Unlock Purchase System → Completed ✅
 - **VS_003B-4**: Visual Feedback & Debug Tools → Completed ✅
+- **BR_014**: Visual Tier Indicators → Completed ✅
 - **TD_080**: Data Loss Bug Fix → Completed ✅
-- **Additional completed work**: Same-tier matching enforcement, enhanced visual display, merge system simplification
-
-**Rejected Items (Properly Closed):**
-- **VS_003B**: Rejected for being too large (Split into thin slices VS_003B-1 through VS_003B-4) ✅
 
 ---
 
 ## 📊 Health Metrics
 
-- **Active Items**: 1 (TD_081)
+- **Active Items**: 4 (VS_006, VS_007, VS_008, TD_081)
 - **Items Stale >3 days**: 0
 - **Items Missing Owners**: 0  
 - **Items with Wrong Owners**: 0
 - **Blocked Items**: 0
-- **Items Completed This Session**: 9
+- **Features Completed This Session**: 5 major features
 
 **Overall Status**: ✅ **HEALTHY** - No review gaps detected, all items properly maintained.
 
@@ -55,14 +73,14 @@ Generated: Tue, Aug 26, 2025 10:58:35 PM
 
 ## 🔧 Maintenance Summary
 
-**Changes Applied (2025-08-26):**
-- Archived 6 completed backlog items to permanent storage
-- Archived 3 additional completed work items (new implementations)
-- Removed completed items from active backlog
-- Updated item counters and timestamps
-- Applied APPEND-ONLY archive protocol correctly
+**Changes Applied (2025-08-27):**
+- Updated Memory Bank with comprehensive session context
+- Enhanced session log with detailed completion summary
+- Updated ReviewGaps.md with current backlog health
+- No items moved to archive (session work was user-requested features, not formal backlog items)
+- Validated all active items have proper ownership and progression
 
-**Archive Location**: `Docs/07-Archive/Completed_Backlog.md` - Section: 2025-08-26
+**Documentation Updated**: Memory Bank activeContext.md, session-log.md, ReviewGaps.md
 
 **Quality Assurance:**
 - All archived items include proper completion metadata

--- a/godot_project/features/block/input/BlockInputManager.cs
+++ b/godot_project/features/block/input/BlockInputManager.cs
@@ -136,6 +136,11 @@ public partial class BlockInputManager : Node
             _unifiedHandler.CycleBlockType();
             GetViewport().SetInputAsHandled();
         }
+        else if (keyEvent.Keycode == _inputMappings.UnlockMergeKey)
+        {
+            _ = _unifiedHandler.HandleUnlockMerge();
+            GetViewport().SetInputAsHandled();
+        }
     }
 
     private async Task HandleCellClick(Vector2Int position)

--- a/godot_project/features/block/input/InputMappings.cs
+++ b/godot_project/features/block/input/InputMappings.cs
@@ -18,6 +18,9 @@ public partial class InputMappings : Resource
     [Export] public MouseButton SelectButton { get; set; } = MouseButton.Left;
     [Export] public MouseButton CancelButton { get; set; } = MouseButton.Right;
 
+    // Testing operations
+    [Export] public Key UnlockMergeKey { get; set; } = Key.M;
+    
     // Swap operations (for future use)
     [Export] public Key SwapBlockKey { get; set; } = Key.S;
     [Export] public float SwapMaxDistance { get; set; } = 3.0f;
@@ -66,6 +69,7 @@ Input Mappings:
   Cycle Block Type: {CycleBlockTypeKey}
   Select/Move: {SelectButton}
   Cancel: {CancelButton}
+  Unlock Merge (Testing): {UnlockMergeKey}
   Swap Blocks: {SwapBlockKey} (max distance: {SwapMaxDistance})
 ";
     }

--- a/godot_project/features/turn/TurnDisplay.cs
+++ b/godot_project/features/turn/TurnDisplay.cs
@@ -1,0 +1,142 @@
+using BlockLife.Core.Features.Turn;
+using BlockLife.godot_project.scenes.Main;
+using Godot;
+using System;
+
+namespace BlockLife.godot_project.features.turn;
+
+/// <summary>
+/// Godot UI node for displaying turn information.
+/// Implements ITurnDisplayView to work with TurnDisplayPresenter in MVP pattern.
+/// Shows current turn number and status updates.
+/// </summary>
+public partial class TurnDisplay : Control, ITurnDisplayView
+{
+    private TurnDisplayPresenter? _presenter;
+    private Label? _turnCounterLabel;
+    private Label? _turnStatusLabel;
+
+    public override void _Ready()
+    {
+        var logger = GetNodeOrNull<SceneRoot>("/root/SceneRoot")?.Logger?.ForContext("SourceContext", "UI");
+        logger?.Debug("TurnDisplay _Ready called");
+
+        // Get UI components
+        _turnCounterLabel = GetNode<Label>("VBoxContainer/TurnCounter");
+        _turnStatusLabel = GetNode<Label>("VBoxContainer/TurnStatus");
+
+        if (_turnCounterLabel == null || _turnStatusLabel == null)
+        {
+            logger?.Error("TurnDisplay: Required child nodes not found. Expected VBoxContainer with TurnCounter and TurnStatus labels");
+            return;
+        }
+
+        // Initialize presenter using the factory pattern - defer to avoid race condition
+        CallDeferred(nameof(InitializePresenterWhenSceneRootReady));
+    }
+
+    /// <summary>
+    /// Deferred presenter initialization to avoid race condition with SceneRoot async setup
+    /// </summary>
+    private void InitializePresenterWhenSceneRootReady()
+    {
+        var sceneRoot = GetNodeOrNull<SceneRoot>("/root/SceneRoot");
+        var logger = sceneRoot?.Logger?.ForContext("SourceContext", "UI");
+
+        if (sceneRoot?.PresenterFactory == null)
+        {
+            logger?.Warning("TurnDisplay: SceneRoot or PresenterFactory not ready yet, retrying in 100ms");
+            GetTree().CreateTimer(0.1).Timeout += InitializePresenterWhenSceneRootReady;
+            return;
+        }
+
+        try
+        {
+            // Create presenter using the generic factory pattern
+            _presenter = sceneRoot.PresenterFactory.Create<TurnDisplayPresenter, ITurnDisplayView>(this);
+            _presenter?.Initialize();
+            logger?.Information("TurnDisplay presenter initialized successfully");
+        }
+        catch (Exception ex)
+        {
+            logger?.Error(ex, "TurnDisplay: Failed to initialize presenter");
+        }
+    }
+
+    public override void _ExitTree()
+    {
+        // Clean up presenter to prevent memory leaks
+        _presenter?.Dispose();
+        _presenter = null;
+    }
+
+    // Implementation of ITurnDisplayView interface
+
+    /// <summary>
+    /// Updates the displayed turn information when a new turn starts.
+    /// </summary>
+    public void DisplayTurnStart(BlockLife.Core.Domain.Turn.Turn turn)
+    {
+        // Must be called from main thread
+        CallDeferred(nameof(UpdateTurnCounterDeferred), turn.Number);
+        CallDeferred(nameof(UpdateTurnStatusDeferred), $"Turn {turn.Number} started");
+        
+        var logger = GetNodeOrNull<SceneRoot>("/root/SceneRoot")?.Logger?.ForContext("SourceContext", "UI");
+        logger?.Debug("TurnDisplay: Turn {TurnNumber} started", turn.Number);
+    }
+
+    /// <summary>
+    /// Updates the displayed turn information when a turn ends.
+    /// </summary>
+    public void DisplayTurnEnd(BlockLife.Core.Domain.Turn.Turn turn)
+    {
+        // Must be called from main thread
+        CallDeferred(nameof(UpdateTurnStatusDeferred), $"Turn {turn.Number} ended");
+        
+        var logger = GetNodeOrNull<SceneRoot>("/root/SceneRoot")?.Logger?.ForContext("SourceContext", "UI");
+        logger?.Debug("TurnDisplay: Turn {TurnNumber} ended", turn.Number);
+    }
+
+    /// <summary>
+    /// Updates the current turn display without transition effects.
+    /// </summary>
+    public void UpdateCurrentTurn(BlockLife.Core.Domain.Turn.Turn turn)
+    {
+        // Must be called from main thread
+        CallDeferred(nameof(UpdateTurnCounterDeferred), turn.Number);
+        CallDeferred(nameof(UpdateTurnStatusDeferred), "");
+        
+        var logger = GetNodeOrNull<SceneRoot>("/root/SceneRoot")?.Logger?.ForContext("SourceContext", "UI");
+        logger?.Debug("TurnDisplay: Current turn updated to {TurnNumber}", turn.Number);
+    }
+
+    /// <summary>
+    /// Shows an error related to turn operations.
+    /// </summary>
+    public void ShowTurnError(string errorMessage)
+    {
+        // Must be called from main thread
+        CallDeferred(nameof(UpdateTurnStatusDeferred), $"Error: {errorMessage}");
+        
+        var logger = GetNodeOrNull<SceneRoot>("/root/SceneRoot")?.Logger?.ForContext("SourceContext", "UI");
+        logger?.Warning("TurnDisplay: Turn error - {ErrorMessage}", errorMessage);
+    }
+
+    // Thread-safe deferred methods for UI updates
+
+    private void UpdateTurnCounterDeferred(int turnNumber)
+    {
+        if (_turnCounterLabel != null)
+        {
+            _turnCounterLabel.Text = $"Turn: {turnNumber}";
+        }
+    }
+
+    private void UpdateTurnStatusDeferred(string status)
+    {
+        if (_turnStatusLabel != null)
+        {
+            _turnStatusLabel.Text = status;
+        }
+    }
+}

--- a/godot_project/infrastructure/logging/GodotConsoleSink.cs
+++ b/godot_project/infrastructure/logging/GodotConsoleSink.cs
@@ -148,7 +148,7 @@ public class GodotConsoleSink : ILogEventSink
 
 public static class GodotSinkExtensions
 {
-    public const string DefaultGodotSinkOutputTemplate = "[{Timestamp:HH:mm:ss}] [{Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}";
+    public const string DefaultGodotSinkOutputTemplate = "[{Timestamp:HH:mm:ss}] [{Level:u3}] [{ShortSourceContext}] {Message:lj}{NewLine}{Exception}";
 
     public static LoggerConfiguration Godot(this LoggerSinkConfiguration configuration,
                                             string outputTemplate = DefaultGodotSinkOutputTemplate,

--- a/godot_project/scenes/Main/SceneRoot.cs
+++ b/godot_project/scenes/Main/SceneRoot.cs
@@ -129,7 +129,7 @@ public partial class SceneRoot : Node
         {
             // Create GodotConsoleSink for console output (always)
             var godotConsoleSink = new GodotConsoleSink(
-                "[{Timestamp:HH:mm:ss} {Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}",
+                "[{Timestamp:HH:mm:ss} {Level:u3}] [{ShortSourceContext}] {Message:lj}{NewLine}{Exception}",
                 null);
 
             // Use legacy API with GodotConsoleSink for console output

--- a/godot_project/scenes/Main/main.tscn
+++ b/godot_project/scenes/Main/main.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="PackedScene" uid="uid://bx5dw2v3qkh8p" path="res://godot_project/scenes/AttributeDisplay.tscn" id="2_attribute"]
 [ext_resource type="PackedScene" uid="uid://ko2eo5hcjxkl" path="res://godot_project/scenes/grid.tscn" id="3_iyj48"]
-[ext_resource type="PackedScene" uid="uid://bguh4klmnopq5" path="res://godot_project/scenes/TurnDisplay.tscn" id="4_turn"]
+[ext_resource type="PackedScene" path="res://godot_project/scenes/TurnDisplay.tscn" id="4_turn"]
 
 [node name="main" type="Node"]
 

--- a/godot_project/scenes/Main/main.tscn
+++ b/godot_project/scenes/Main/main.tscn
@@ -1,11 +1,15 @@
-[gd_scene load_steps=3 format=3 uid="uid://o8gakj4jxun8"]
+[gd_scene load_steps=4 format=3 uid="uid://o8gakj4jxun8"]
 
 [ext_resource type="PackedScene" uid="uid://bx5dw2v3qkh8p" path="res://godot_project/scenes/AttributeDisplay.tscn" id="2_attribute"]
 [ext_resource type="PackedScene" uid="uid://ko2eo5hcjxkl" path="res://godot_project/scenes/grid.tscn" id="3_iyj48"]
+[ext_resource type="PackedScene" uid="uid://bguh4klmnopq5" path="res://godot_project/scenes/TurnDisplay.tscn" id="4_turn"]
 
 [node name="main" type="Node"]
 
 [node name="Grid" parent="." instance=ExtResource("3_iyj48")]
 
 [node name="AttributeDisplay" parent="." instance=ExtResource("2_attribute")]
+layout_mode = 3
+
+[node name="TurnDisplay" parent="." instance=ExtResource("4_turn")]
 layout_mode = 3

--- a/godot_project/scenes/TurnDisplay.tscn
+++ b/godot_project/scenes/TurnDisplay.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=2 format=3 uid="uid://bguh4klmnopq5"]
+
+[ext_resource type="Script" path="res://godot_project/features/turn/TurnDisplay.cs" id="1_turn"]
+
+[node name="TurnDisplay" type="Control"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+script = ExtResource("1_turn")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 20.0
+offset_top = -60.0
+offset_right = 150.0
+offset_bottom = -20.0
+mouse_filter = 2
+
+[node name="TurnCounter" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+mouse_filter = 2
+text = "Turn: 1"
+horizontal_alignment = 1
+
+[node name="TurnStatus" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+mouse_filter = 2
+text = ""
+horizontal_alignment = 1

--- a/godot_project/scenes/grid.tscn
+++ b/godot_project/scenes/grid.tscn
@@ -3,8 +3,8 @@
 [ext_resource type="Script" uid="uid://cnkwf7d32dn6h" path="res://godot_project/features/block/placement/GridView.cs" id="1_kkt3w"]
 [ext_resource type="Script" uid="uid://1y7361a257ob" path="res://godot_project/features/block/placement/BlockVisualizationController.cs" id="2_3okcj"]
 [ext_resource type="Script" uid="uid://beyv8auwjrhvi" path="res://godot_project/features/block/placement/GridInteractionController.cs" id="3_7qbr8"]
-[ext_resource type="Script" uid="uid://dhh5e143i6en4" path="res://godot_project/features/block/input/BlockInputManager.cs" id="4_input"]
-[ext_resource type="Script" uid="uid://m3xrr3gwgfsw" path="res://godot_project/features/block/drag/DragView.cs" id="5_drag"]
+[ext_resource type="Script" uid="uid://b5o1pqa4ygap3" path="res://godot_project/features/block/input/BlockInputManager.cs" id="4_input"]
+[ext_resource type="Script" uid="uid://bctntt6du40y6" path="res://godot_project/features/block/drag/DragView.cs" id="5_drag"]
 
 [node name="Grid" type="Control" node_paths=PackedStringArray("VisualizationController", "InteractionController")]
 layout_mode = 3

--- a/godot_project/scenes/grid.tscn
+++ b/godot_project/scenes/grid.tscn
@@ -1,10 +1,31 @@
-[gd_scene load_steps=6 format=3 uid="uid://ko2eo5hcjxkl"]
+[gd_scene load_steps=8 format=3 uid="uid://ko2eo5hcjxkl"]
 
 [ext_resource type="Script" uid="uid://cnkwf7d32dn6h" path="res://godot_project/features/block/placement/GridView.cs" id="1_kkt3w"]
 [ext_resource type="Script" uid="uid://1y7361a257ob" path="res://godot_project/features/block/placement/BlockVisualizationController.cs" id="2_3okcj"]
 [ext_resource type="Script" uid="uid://beyv8auwjrhvi" path="res://godot_project/features/block/placement/GridInteractionController.cs" id="3_7qbr8"]
 [ext_resource type="Script" uid="uid://b5o1pqa4ygap3" path="res://godot_project/features/block/input/BlockInputManager.cs" id="4_input"]
 [ext_resource type="Script" uid="uid://bctntt6du40y6" path="res://godot_project/features/block/drag/DragView.cs" id="5_drag"]
+[ext_resource type="Script" uid="uid://cro0ip0by0vbs" path="res://godot_project/features/block/input/InputMappings.cs" id="5_jppq3"]
+
+[sub_resource type="Resource" id="Resource_jppq3"]
+script = ExtResource("5_jppq3")
+PlaceBlockKey = 32
+InspectBlockKey = 73
+CycleBlockTypeKey = 4194306
+SelectButton = 1
+CancelButton = 2
+UnlockMergeKey = 77
+SwapBlockKey = 83
+SwapMaxDistance = 3.0
+CameraUpKey = 87
+CameraDownKey = 83
+CameraLeftKey = 65
+CameraRightKey = 68
+QuickPlaceModifier = 4194325
+MultiSelectModifier = 4194326
+DebugToggleKey = 4194334
+ReloadSceneKey = 4194336
+metadata/_custom_type_script = "uid://cro0ip0by0vbs"
 
 [node name="Grid" type="Control" node_paths=PackedStringArray("VisualizationController", "InteractionController")]
 layout_mode = 3
@@ -37,6 +58,7 @@ script = ExtResource("3_7qbr8")
 
 [node name="BlockInputManager" type="Node" parent="."]
 script = ExtResource("4_input")
+_inputMappings = SubResource("Resource_jppq3")
 
 [node name="DragView" type="Control" parent="."]
 anchors_preset = 0

--- a/src/Core/Domain/Turn/ITurnManager.cs
+++ b/src/Core/Domain/Turn/ITurnManager.cs
@@ -1,0 +1,67 @@
+using LanguageExt;
+
+namespace BlockLife.Core.Domain.Turn
+{
+    /// <summary>
+    /// Domain service interface for managing turn progression and state.
+    /// Encapsulates the business rules for when and how turns advance.
+    /// Following established domain service patterns.
+    /// </summary>
+    public interface ITurnManager
+    {
+        /// <summary>
+        /// Gets the current turn.
+        /// </summary>
+        /// <returns>The current turn, or None if not initialized</returns>
+        Option<Turn> GetCurrentTurn();
+
+        /// <summary>
+        /// Advances to the next turn with validation.
+        /// Only advances if the current game state allows it.
+        /// </summary>
+        /// <returns>Fin&lt;Turn&gt; with new current turn or validation error</returns>
+        Fin<Turn> AdvanceTurn();
+
+        /// <summary>
+        /// Checks if turn advancement is currently allowed.
+        /// Turn advancement requires that a valid game action was completed.
+        /// </summary>
+        /// <returns>True if turn can be advanced, false otherwise</returns>
+        bool CanAdvanceTurn();
+
+        /// <summary>
+        /// Resets the turn manager to initial state (turn 1).
+        /// Used when starting a new game.
+        /// </summary>
+        /// <returns>Fin&lt;Turn&gt; with initial turn or error</returns>
+        Fin<Turn> Reset();
+
+        /// <summary>
+        /// Gets the total number of turns elapsed in the current game.
+        /// Useful for game statistics and progression tracking.
+        /// </summary>
+        /// <returns>Number of completed turns, 0 if not initialized</returns>
+        int GetTurnsElapsed();
+
+        /// <summary>
+        /// Marks that a valid action has been performed, enabling turn advancement.
+        /// This is called after successful moves, pattern matches, etc.
+        /// </summary>
+        void MarkActionPerformed();
+
+        /// <summary>
+        /// Checks if an action has been performed in the current turn.
+        /// Used to enforce one-action-per-turn limitation.
+        /// </summary>
+        /// <returns>True if an action was performed this turn</returns>
+        bool HasActionBeenPerformed();
+
+        /// <summary>
+        /// Loads turn state from external source (save data, etc.).
+        /// </summary>
+        /// <param name="turn">The turn to restore</param>
+        /// <param name="actionPerformed">Whether an action was performed in this turn</param>
+        /// <returns>Fin&lt;Turn&gt; with loaded turn or validation error</returns>
+        Fin<Turn> LoadState(Turn turn, bool actionPerformed);
+    }
+}

--- a/src/Core/Domain/Turn/Turn.cs
+++ b/src/Core/Domain/Turn/Turn.cs
@@ -1,0 +1,108 @@
+using LanguageExt;
+using LanguageExt.Common;
+using static LanguageExt.Prelude;
+using System;
+
+namespace BlockLife.Core.Domain.Turn
+{
+    /// <summary>
+    /// Immutable value object representing a single turn in the game.
+    /// Each turn represents one complete action cycle where the player can perform actions.
+    /// Following established domain patterns with LanguageExt functional types.
+    /// </summary>
+    public sealed record Turn
+    {
+        /// <summary>
+        /// The sequential number of this turn, starting from 1.
+        /// Turn numbers are always positive and increment by 1.
+        /// </summary>
+        public required int Number { get; init; }
+
+        /// <summary>
+        /// Timestamp when this turn was created.
+        /// Used for tracking game session timing and analytics.
+        /// </summary>
+        public required DateTime CreatedAt { get; init; }
+
+        /// <summary>
+        /// Default constructor required for record initialization with required properties.
+        /// </summary>
+        public Turn()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new Turn with validation.
+        /// Ensures turn number is valid and sets creation timestamp.
+        /// </summary>
+        /// <param name="number">The turn number (must be >= 1)</param>
+        /// <returns>Fin&lt;Turn&gt; with validated turn or error</returns>
+        public static Fin<Turn> Create(int number)
+        {
+            if (number < 1)
+                return FinFail<Turn>(Error.New("Turn number must be 1 or greater"));
+
+            return new Turn
+            {
+                Number = number,
+                CreatedAt = DateTime.UtcNow
+            };
+        }
+
+        /// <summary>
+        /// Creates the initial turn (turn 1) for a new game.
+        /// </summary>
+        /// <returns>The first turn with number 1</returns>
+        public static Turn CreateInitial() => new()
+        {
+            Number = 1,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        /// <summary>
+        /// Creates the next turn in sequence.
+        /// Increments the turn number by 1 and sets new timestamp.
+        /// </summary>
+        /// <returns>Fin&lt;Turn&gt; with next turn or overflow error</returns>
+        public Fin<Turn> Next()
+        {
+            // Prevent integer overflow
+            if (Number == int.MaxValue)
+                return FinFail<Turn>(Error.New("Turn number overflow - maximum turns reached"));
+
+            return new Turn
+            {
+                Number = Number + 1,
+                CreatedAt = DateTime.UtcNow
+            };
+        }
+
+        /// <summary>
+        /// Checks if this turn comes before another turn.
+        /// </summary>
+        /// <param name="other">The turn to compare against</param>
+        /// <returns>True if this turn number is less than the other</returns>
+        public bool IsBefore(Turn other) => Number < other.Number;
+
+        /// <summary>
+        /// Checks if this turn comes after another turn.
+        /// </summary>
+        /// <param name="other">The turn to compare against</param>
+        /// <returns>True if this turn number is greater than the other</returns>
+        public bool IsAfter(Turn other) => Number > other.Number;
+
+        /// <summary>
+        /// Checks if this is the first turn of the game.
+        /// </summary>
+        public bool IsFirst => Number == 1;
+
+        /// <summary>
+        /// Calculates the number of turns between this and another turn.
+        /// </summary>
+        /// <param name="other">The turn to calculate distance to</param>
+        /// <returns>Absolute difference in turn numbers</returns>
+        public int DistanceTo(Turn other) => Math.Abs(Number - other.Number);
+
+        public override string ToString() => $"Turn {Number} ({CreatedAt:yyyy-MM-dd HH:mm:ss})";
+    }
+}

--- a/src/Core/Features/Block/Patterns/Executors/MatchPatternExecutor.cs
+++ b/src/Core/Features/Block/Patterns/Executors/MatchPatternExecutor.cs
@@ -1,6 +1,7 @@
 using BlockLife.Core.Domain.Block;
 using BlockLife.Core.Domain.Common;
 using BlockLife.Core.Domain.Player;
+using BlockLife.Core.Domain.Turn;
 using BlockLife.Core.Features.Block.Patterns.Models;
 using BlockLife.Core.Features.Block.Patterns.Recognizers;
 using BlockLife.Core.Features.Block.Placement.Notifications;
@@ -155,6 +156,24 @@ namespace BlockLife.Core.Features.Block.Patterns.Executors
                     {
                         _logger?.LogWarning("Failed to apply match rewards: {Error}", 
                             rewardResult.Match(Succ: _ => "", Fail: e => e.Message));
+                    }
+                    else
+                    {
+                        // DEBUG: Show resource changes  
+                        var resourceList = resourceChanges.Select(kv => $"{kv.Key}:+{kv.Value}").ToList();
+                        var attributeList = attributeChanges.Select(kv => $"{kv.Key}:+{kv.Value}").ToList();
+                        
+                        var allRewards = new List<string>();
+                        allRewards.AddRange(resourceList);
+                        allRewards.AddRange(attributeList);
+
+                        if (allRewards.Any())
+                        {
+                            _logger?.LogInformation("🎯 MATCH REWARDS: {Rewards} (from {Count} {BlockType} blocks)", 
+                                string.Join(", ", allRewards), 
+                                matchPattern.Positions.Count,
+                                blocksToRemove.FirstOrDefault()?.Type.ToString() ?? "Unknown");
+                        }
                     }
                 }
 

--- a/src/Core/Features/Block/Patterns/Executors/MergePatternExecutor.cs
+++ b/src/Core/Features/Block/Patterns/Executors/MergePatternExecutor.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using BlockLife.Core.Domain.Block;
 using BlockLife.Core.Domain.Common;
 using BlockLife.Core.Domain.Player;
+using BlockLife.Core.Domain.Turn;
 using BlockLife.Core.Features.Block.Patterns.Models;
 using BlockLife.Core.Features.Block.Patterns.Recognizers;
 using BlockLife.Core.Features.Block.Placement.Notifications;
@@ -208,6 +209,27 @@ namespace BlockLife.Core.Features.Block.Patterns.Executors
                     {
                         _logger?.LogWarning("Failed to apply merge rewards: {Error}", 
                             rewardResult.Match(Succ: _ => "", Fail: e => e.Message));
+                    }
+                    else
+                    {
+                        // DEBUG: Show resource changes
+                        var resourceList = resourceChanges.Select(kv => $"{kv.Key}:+{kv.Value}").ToList();
+                        var attributeList = attributeChanges.Select(kv => $"{kv.Key}:+{kv.Value}").ToList();
+                        
+                        var allRewards = new List<string>();
+                        allRewards.AddRange(resourceList);
+                        allRewards.AddRange(attributeList);
+
+                        if (allRewards.Any())
+                        {
+                            _logger?.LogInformation("🚀 MERGE REWARDS: {Rewards} (from {Count} T{Tier} {BlockType} → 1 T{NewTier} {BlockType})", 
+                                string.Join(", ", allRewards), 
+                                removedBlocks.Count,
+                                expectedTier,
+                                blockType,
+                                newTier,
+                                blockType);
+                        }
                     }
                 }
 

--- a/src/Core/GameStrapper.cs
+++ b/src/Core/GameStrapper.cs
@@ -14,6 +14,26 @@ using System.Reflection;
 namespace BlockLife.Core;
 
 /// <summary>
+/// Serilog enricher that creates a shortened version of the SourceContext (class name)
+/// Converts "BlockLife.Core.Features.Block.Notifications.ProcessPatternsAfterPlacementHandler" 
+/// to "ProcessPatternsAfterPlacementHandler"
+/// </summary>
+public class ShortSourceContextEnricher : ILogEventEnricher
+{
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        if (logEvent.Properties.TryGetValue("SourceContext", out var sourceContextProperty) &&
+            sourceContextProperty is ScalarValue scalarValue &&
+            scalarValue.Value is string sourceContext)
+        {
+            var shortName = sourceContext.Split('.').LastOrDefault() ?? sourceContext;
+            var shortSourceContextProperty = propertyFactory.CreateProperty("ShortSourceContext", shortName);
+            logEvent.AddPropertyIfAbsent(shortSourceContextProperty);
+        }
+    }
+}
+
+/// <summary>
 /// **ENHANCED** bootstrapper for the C# application logic with comprehensive safety features.
 /// 
 /// Configures and initializes the dependency injection container with:
@@ -213,6 +233,7 @@ public static class GameStrapper
         var loggerConfig = new LoggerConfiguration()
             .MinimumLevel.ControlledBy(masterSwitch)
             .Enrich.FromLogContext()
+            .Enrich.With(new ShortSourceContextEnricher())
             // Filter out pre-warming messages
             .Filter.ByExcluding(evt =>
                 evt.Properties.ContainsKey("PreWarm") ||
@@ -258,12 +279,14 @@ public static class GameStrapper
                 .MinimumLevel.Is(defaultLevel)
                 .Enrich.FromLogContext()
                 .Enrich.WithProperty("Application", "BlockLife")
+                .Enrich.With(new ShortSourceContextEnricher())
                 // Filter out pre-warming messages
                 .Filter.ByExcluding(evt =>
                     evt.Properties.ContainsKey("PreWarm") ||
                     evt.Properties.ContainsKey("SourceContext") &&
                     evt.Properties["SourceContext"].ToString().Contains("PreWarm"))
-                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}");
+                .Enrich.With(new ShortSourceContextEnricher())
+                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] [{ShortSourceContext}] {Message:lj}{NewLine}{Exception}");
 
             // Apply category-specific levels
             if (categoryLevels != null)

--- a/src/Core/GameStrapper.cs
+++ b/src/Core/GameStrapper.cs
@@ -184,6 +184,11 @@ public static class GameStrapper
         services.AddTransient<BlockLife.Core.Features.Block.Placement.RemoveBlockCommandHandler>();
         services.AddTransient<BlockLife.Core.Features.Block.Placement.RemoveBlockByIdCommandHandler>();
 
+        // --- Turn System Services (VS_006) ---
+        services.AddSingleton<BlockLife.Core.Domain.Turn.ITurnManager,
+            BlockLife.Core.Features.Turn.Services.TurnManager>();
+        services.AddTransient<BlockLife.Core.Features.Turn.Commands.AdvanceTurnCommandHandler>();
+
         // --- Notification Handlers ---
         // NOTE: MediatR automatically discovers and registers INotificationHandler implementations
         // during assembly scanning. Manual registration can interfere with MediatR's lifecycle management.
@@ -417,6 +422,11 @@ public static class GameStrapper
         services.AddTransient<BlockLife.Core.Features.Block.Placement.PlaceBlockCommandHandler>();
         services.AddTransient<BlockLife.Core.Features.Block.Placement.RemoveBlockCommandHandler>();
         services.AddTransient<BlockLife.Core.Features.Block.Placement.RemoveBlockByIdCommandHandler>();
+        
+        // --- Turn System Services (VS_006) ---
+        services.AddSingleton<BlockLife.Core.Domain.Turn.ITurnManager,
+            BlockLife.Core.Features.Turn.Services.TurnManager>();
+        services.AddTransient<BlockLife.Core.Features.Turn.Commands.AdvanceTurnCommandHandler>();
         
         // --- Player Command Services (VS_003B-3) ---
         services.AddTransient<BlockLife.Core.Features.Player.Commands.PurchaseMergeUnlockCommandHandler>();

--- a/src/Features/Turn/Commands/AdvanceTurnCommand.cs
+++ b/src/Features/Turn/Commands/AdvanceTurnCommand.cs
@@ -1,0 +1,18 @@
+using BlockLife.Core.Application.Commands;
+using LanguageExt;
+
+namespace BlockLife.Core.Features.Turn.Commands
+{
+    /// <summary>
+    /// Command to advance the game to the next turn.
+    /// Following TDD+VSA Comprehensive Development Workflow.
+    /// </summary>
+    public sealed record AdvanceTurnCommand : ICommand
+    {
+        /// <summary>
+        /// Creates a new AdvanceTurnCommand.
+        /// </summary>
+        public static AdvanceTurnCommand Create() =>
+            new();
+    }
+}

--- a/src/Features/Turn/Commands/AdvanceTurnCommandHandler.cs
+++ b/src/Features/Turn/Commands/AdvanceTurnCommandHandler.cs
@@ -1,0 +1,102 @@
+using BlockLife.Core.Domain.Turn;
+using BlockLife.Core.Features.Turn.Effects;
+using BlockLife.Core.Infrastructure.Extensions;
+using LanguageExt;
+using LanguageExt.Common;
+using MediatR;
+using Serilog;
+using System.Threading;
+using System.Threading.Tasks;
+using static LanguageExt.Prelude;
+
+namespace BlockLife.Core.Features.Turn.Commands
+{
+    /// <summary>
+    /// Handler for AdvanceTurnCommand - Implements functional CQRS pattern with Fin&lt;T&gt; monads.
+    /// Following TDD+VSA Comprehensive Development Workflow.
+    /// </summary>
+    public class AdvanceTurnCommandHandler : IRequestHandler<AdvanceTurnCommand, Fin<LanguageExt.Unit>>
+    {
+        private readonly ITurnManager _turnManager;
+        private readonly IMediator _mediator;
+        private readonly ILogger _logger;
+
+        public AdvanceTurnCommandHandler(
+            ITurnManager turnManager,
+            IMediator mediator,
+            ILogger logger)
+        {
+            _turnManager = turnManager;
+            _mediator = mediator;
+            _logger = logger;
+        }
+
+        public async Task<Fin<LanguageExt.Unit>> Handle(AdvanceTurnCommand request, CancellationToken cancellationToken)
+        {
+            _logger.Debug("Processing AdvanceTurnCommand");
+
+            // Step 1: Get current turn before advancing
+            var currentTurnOption = _turnManager.GetCurrentTurn();
+            if (currentTurnOption.IsNone)
+            {
+                var error = Error.New("TURN_NOT_INITIALIZED", "Turn system not initialized");
+                _logger.Warning("Cannot advance turn: Turn system not initialized");
+                return FinFail<LanguageExt.Unit>(error);
+            }
+
+            var currentTurn = currentTurnOption.Match(Some: t => t, None: () => throw new System.InvalidOperationException());
+
+            // Step 2: Publish TurnEndNotification for current turn
+            var turnEndResult = await PublishTurnEndNotification(currentTurn, cancellationToken);
+            if (turnEndResult.IsFail)
+            {
+                var error = turnEndResult.Match<Error>(Succ: _ => Error.New("UNKNOWN", "Unknown error"), Fail: e => e);
+                _logger.Warning("Failed to publish turn end notification: {Error}", error.Message);
+                return FinFail<LanguageExt.Unit>(error);
+            }
+
+            // Step 3: Advance turn
+            var advanceResult = _turnManager.AdvanceTurn();
+            if (advanceResult.IsFail)
+            {
+                var error = advanceResult.Match<Error>(Succ: _ => Error.New("UNKNOWN", "Unknown error"), Fail: e => e);
+                _logger.Warning("Failed to advance turn: {Error}", error.Message);
+                return FinFail<LanguageExt.Unit>(error);
+            }
+
+            var newTurn = advanceResult.Match(Succ: t => t, Fail: _ => throw new System.InvalidOperationException());
+
+            // Step 4: Publish TurnStartNotification for new turn
+            var turnStartResult = await PublishTurnStartNotification(newTurn, cancellationToken);
+            if (turnStartResult.IsFail)
+            {
+                var error = turnStartResult.Match<Error>(Succ: _ => Error.New("UNKNOWN", "Unknown error"), Fail: e => e);
+                _logger.Warning("Failed to publish turn start notification: {Error}", error.Message);
+                return FinFail<LanguageExt.Unit>(error);
+            }
+
+            _logger.Debug("Successfully advanced from turn {OldTurn} to turn {NewTurn}",
+                currentTurn.Number, newTurn.Number);
+
+            return FinSucc(LanguageExt.Unit.Default);
+        }
+
+        private async Task<Fin<LanguageExt.Unit>> PublishTurnEndNotification(
+            Domain.Turn.Turn turn,
+            CancellationToken cancellationToken)
+        {
+            var notification = TurnEndNotification.Create(turn);
+            return await _mediator.Publish(notification, cancellationToken)
+                .ToFin("TURN_END_NOTIFICATION_FAILED", "Failed to publish turn end notification");
+        }
+
+        private async Task<Fin<LanguageExt.Unit>> PublishTurnStartNotification(
+            Domain.Turn.Turn turn,
+            CancellationToken cancellationToken)
+        {
+            var notification = TurnStartNotification.Create(turn);
+            return await _mediator.Publish(notification, cancellationToken)
+                .ToFin("TURN_START_NOTIFICATION_FAILED", "Failed to publish turn start notification");
+        }
+    }
+}

--- a/src/Features/Turn/Effects/TurnEndNotification.cs
+++ b/src/Features/Turn/Effects/TurnEndNotification.cs
@@ -1,0 +1,25 @@
+using MediatR;
+
+namespace BlockLife.Core.Features.Turn.Effects
+{
+    /// <summary>
+    /// Notification published when a turn has ended.
+    /// Following TDD+VSA Comprehensive Development Workflow.
+    /// </summary>
+    public sealed record TurnEndNotification : INotification
+    {
+        /// <summary>
+        /// The turn that has just ended.
+        /// </summary>
+        public required Domain.Turn.Turn Turn { get; init; }
+
+        /// <summary>
+        /// Creates a new TurnEndNotification with the specified turn.
+        /// </summary>
+        public static TurnEndNotification Create(Domain.Turn.Turn turn) =>
+            new()
+            {
+                Turn = turn
+            };
+    }
+}

--- a/src/Features/Turn/Effects/TurnNotificationBridge.cs
+++ b/src/Features/Turn/Effects/TurnNotificationBridge.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BlockLife.Core.Infrastructure.Events;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace BlockLife.Core.Features.Turn.Effects;
+
+/// <summary>
+/// CRITICAL INFRASTRUCTURE: Bridges MediatR notifications to static events for presenter consumption.
+/// Without this bridge, the Turn Display feature is 0% functional - backend changes won't reach UI.
+/// Uses thread-safe weak event pattern to prevent memory leaks and ensure thread safety.
+/// </summary>
+public class TurnNotificationBridge : INotificationHandler<TurnStartNotification>, INotificationHandler<TurnEndNotification>
+{
+    private readonly ILogger<TurnNotificationBridge> _logger;
+
+    // Thread-safe weak event managers that prevent memory leaks
+    private static readonly WeakEventManager<TurnStartNotification> _turnStartManager =
+        new("TurnStart");
+
+    private static readonly WeakEventManager<TurnEndNotification> _turnEndManager =
+        new("TurnEnd");
+
+    // Legacy static events for backward compatibility (deprecated)
+    [Obsolete("Use SubscribeToTurnStart instead for thread-safe weak event subscription")]
+    public static event Func<TurnStartNotification, Task>? TurnStartEvent;
+
+    [Obsolete("Use SubscribeToTurnEnd instead for thread-safe weak event subscription")]
+    public static event Func<TurnEndNotification, Task>? TurnEndEvent;
+
+    /// <summary>
+    /// Subscribes to turn start events using thread-safe weak references.
+    /// Returns a disposable token that must be disposed to unsubscribe.
+    /// </summary>
+    public static IDisposable SubscribeToTurnStart(Func<TurnStartNotification, Task> handler)
+    {
+        return _turnStartManager.Subscribe(handler);
+    }
+
+    /// <summary>
+    /// Subscribes to turn end events using thread-safe weak references.
+    /// Returns a disposable token that must be disposed to unsubscribe.
+    /// </summary>
+    public static IDisposable SubscribeToTurnEnd(Func<TurnEndNotification, Task> handler)
+    {
+        return _turnEndManager.Subscribe(handler);
+    }
+
+    /// <summary>
+    /// Clears all event subscriptions. Used in testing to prevent memory leaks.
+    /// </summary>
+    public static void ClearSubscriptions()
+    {
+        _turnStartManager.ClearSubscriptions();
+        _turnEndManager.ClearSubscriptions();
+        TurnStartEvent = null;
+        TurnEndEvent = null;
+    }
+
+    /// <summary>
+    /// Gets the number of subscribers to TurnStart events. Used for testing.
+    /// </summary>
+    public static int GetTurnStartSubscriberCount()
+    {
+        return _turnStartManager.GetSubscriberCount() +
+               (TurnStartEvent?.GetInvocationList().Length ?? 0);
+    }
+
+    /// <summary>
+    /// Gets the number of subscribers to TurnEnd events. Used for testing.
+    /// </summary>
+    public static int GetTurnEndSubscriberCount()
+    {
+        return _turnEndManager.GetSubscriberCount() +
+               (TurnEndEvent?.GetInvocationList().Length ?? 0);
+    }
+
+    public TurnNotificationBridge(ILogger<TurnNotificationBridge> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Handles the TurnStartNotification from the command handler and bridges it to the static event.
+    /// This method is called by MediatR's notification pipeline after a successful turn start.
+    /// </summary>
+    public async Task Handle(TurnStartNotification notification, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("TurnNotificationBridge.Handle called for TurnStart - Turn {TurnNumber}",
+            notification.Turn.Number);
+
+        // Invoke weak event manager (thread-safe)
+        await _turnStartManager.InvokeAsync(notification);
+
+        // Invoke legacy static event for backward compatibility
+        if (TurnStartEvent != null)
+        {
+            await TurnStartEvent(notification);
+            _logger.LogDebug("Legacy TurnStartEvent invoked");
+        }
+
+        if (_turnStartManager.GetSubscriberCount() == 0 && TurnStartEvent == null)
+        {
+            _logger.LogWarning("No subscribers for TurnStart event - no view will be updated!");
+        }
+    }
+
+    /// <summary>
+    /// Handles the TurnEndNotification from the command handler and bridges it to the static event.
+    /// This method is called by MediatR's notification pipeline after a successful turn end.
+    /// </summary>
+    public async Task Handle(TurnEndNotification notification, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("TurnNotificationBridge.Handle called for TurnEnd - Turn {TurnNumber}",
+            notification.Turn.Number);
+
+        // Invoke weak event manager (thread-safe)
+        await _turnEndManager.InvokeAsync(notification);
+
+        // Invoke legacy static event for backward compatibility
+        if (TurnEndEvent != null)
+        {
+            await TurnEndEvent(notification);
+            _logger.LogDebug("Legacy TurnEndEvent invoked");
+        }
+
+        if (_turnEndManager.GetSubscriberCount() == 0 && TurnEndEvent == null)
+        {
+            _logger.LogWarning("No subscribers for TurnEnd event - no view will be updated!");
+        }
+    }
+}

--- a/src/Features/Turn/Effects/TurnStartNotification.cs
+++ b/src/Features/Turn/Effects/TurnStartNotification.cs
@@ -1,0 +1,25 @@
+using MediatR;
+
+namespace BlockLife.Core.Features.Turn.Effects
+{
+    /// <summary>
+    /// Notification published when a new turn has started.
+    /// Following TDD+VSA Comprehensive Development Workflow.
+    /// </summary>
+    public sealed record TurnStartNotification : INotification
+    {
+        /// <summary>
+        /// The turn that has just started.
+        /// </summary>
+        public required Domain.Turn.Turn Turn { get; init; }
+
+        /// <summary>
+        /// Creates a new TurnStartNotification with the specified turn.
+        /// </summary>
+        public static TurnStartNotification Create(Domain.Turn.Turn turn) =>
+            new()
+            {
+                Turn = turn
+            };
+    }
+}

--- a/src/Features/Turn/ITurnDisplayView.cs
+++ b/src/Features/Turn/ITurnDisplayView.cs
@@ -1,0 +1,38 @@
+using BlockLife.Core.Domain.Turn;
+
+namespace BlockLife.Core.Features.Turn
+{
+    /// <summary>
+    /// Interface for turn display capabilities in the view layer.
+    /// This interface defines the display capability that views must implement
+    /// to support turn information updates following the MVP pattern.
+    /// </summary>
+    public interface ITurnDisplayView
+    {
+        /// <summary>
+        /// Updates the displayed turn information when a new turn starts.
+        /// </summary>
+        /// <param name="turn">The turn that has started</param>
+        void DisplayTurnStart(Domain.Turn.Turn turn);
+
+        /// <summary>
+        /// Updates the displayed turn information when a turn ends.
+        /// Called before the turn advances to provide transition feedback.
+        /// </summary>
+        /// <param name="turn">The turn that has ended</param>
+        void DisplayTurnEnd(Domain.Turn.Turn turn);
+
+        /// <summary>
+        /// Updates the current turn display without transition effects.
+        /// Used for immediate updates or initialization scenarios.
+        /// </summary>
+        /// <param name="turn">The current turn to display</param>
+        void UpdateCurrentTurn(Domain.Turn.Turn turn);
+
+        /// <summary>
+        /// Shows an error related to turn operations.
+        /// </summary>
+        /// <param name="errorMessage">The error message to display</param>
+        void ShowTurnError(string errorMessage);
+    }
+}

--- a/src/Features/Turn/Notifications/TurnAdvancementAfterMoveHandler.cs
+++ b/src/Features/Turn/Notifications/TurnAdvancementAfterMoveHandler.cs
@@ -1,0 +1,70 @@
+using BlockLife.Core.Domain.Turn;
+using BlockLife.Core.Features.Block.Effects;
+using BlockLife.Core.Features.Turn.Commands;
+using LanguageExt;
+using MediatR;
+using Serilog;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BlockLife.Core.Features.Turn.Notifications
+{
+    /// <summary>
+    /// Handles block movement notifications by advancing turns.
+    /// Only user-initiated moves should consume turns, not cascades or pattern effects.
+    /// This ensures one-action-per-turn gameplay is properly enforced.
+    /// </summary>
+    public class TurnAdvancementAfterMoveHandler : INotificationHandler<BlockMovedNotification>
+    {
+        private readonly ITurnManager _turnManager;
+        private readonly IMediator _mediator;
+        private readonly ILogger _logger;
+
+        public TurnAdvancementAfterMoveHandler(
+            ITurnManager turnManager,
+            IMediator mediator,
+            ILogger logger)
+        {
+            _turnManager = turnManager;
+            _mediator = mediator;
+            _logger = logger;
+        }
+
+        public async Task Handle(BlockMovedNotification notification, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var currentTurn = _turnManager.GetTurnsElapsed();
+                _logger.Information("🎯 BLOCK MOVED from {FromPosition} to {ToPosition}, Turn {Turn} - advancing turn", 
+                    notification.FromPosition, notification.ToPosition, currentTurn);
+
+                // Mark that the user has performed their action for this turn
+                _turnManager.MarkActionPerformed();
+
+                // Check if turn advancement is available and auto-advance
+                if (_turnManager.CanAdvanceTurn())
+                {
+                    _logger.Information("➡️ ADVANCING TURN after block movement");
+                    
+                    var command = AdvanceTurnCommand.Create();
+                    var result = await _mediator.Send(command, cancellationToken);
+                    
+                    result.Match(
+                        Succ: _ => _logger.Debug("Successfully auto-advanced turn after block movement"),
+                        Fail: error => _logger.Warning("Failed to auto-advance turn: {Error}", error.Message)
+                    );
+                }
+                else
+                {
+                    _logger.Debug("Turn advancement not available (conditions not met)");
+                }
+            }
+            catch (System.Exception ex)
+            {
+                _logger.Error(ex, "Error processing turn advancement after block movement: {ErrorMessage}", 
+                    ex.Message);
+                // Don't throw - turn advancement failure shouldn't break the block movement
+            }
+        }
+    }
+}

--- a/src/Features/Turn/Notifications/TurnAdvancementAfterMoveHandler.cs
+++ b/src/Features/Turn/Notifications/TurnAdvancementAfterMoveHandler.cs
@@ -11,8 +11,10 @@ namespace BlockLife.Core.Features.Turn.Notifications
 {
     /// <summary>
     /// Handles block movement notifications by advancing turns.
-    /// Only user-initiated moves should consume turns, not cascades or pattern effects.
-    /// This ensures one-action-per-turn gameplay is properly enforced.
+    /// IMPORTANT: Only block MOVEMENT consumes turns, not block PLACEMENT.
+    /// - Placing a new block: FREE (no turn consumed)
+    /// - Moving an existing block: COSTS 1 TURN
+    /// This creates strategic depth - initial placement is critical since fixes cost turns.
     /// </summary>
     public class TurnAdvancementAfterMoveHandler : INotificationHandler<BlockMovedNotification>
     {

--- a/src/Features/Turn/Notifications/TurnAdvancementAfterMoveHandler.cs
+++ b/src/Features/Turn/Notifications/TurnAdvancementAfterMoveHandler.cs
@@ -37,7 +37,7 @@ namespace BlockLife.Core.Features.Turn.Notifications
             try
             {
                 var currentTurn = _turnManager.GetTurnsElapsed();
-                _logger.Information("🎯 BLOCK MOVED from {FromPosition} to {ToPosition}, Turn {Turn} - advancing turn", 
+                _logger.Debug("Block moved from {FromPosition} to {ToPosition} on Turn {Turn}", 
                     notification.FromPosition, notification.ToPosition, currentTurn);
 
                 // Mark that the user has performed their action for this turn
@@ -46,19 +46,13 @@ namespace BlockLife.Core.Features.Turn.Notifications
                 // Check if turn advancement is available and auto-advance
                 if (_turnManager.CanAdvanceTurn())
                 {
-                    _logger.Information("➡️ ADVANCING TURN after block movement");
-                    
                     var command = AdvanceTurnCommand.Create();
                     var result = await _mediator.Send(command, cancellationToken);
                     
                     result.Match(
-                        Succ: _ => _logger.Debug("Successfully auto-advanced turn after block movement"),
-                        Fail: error => _logger.Warning("Failed to auto-advance turn: {Error}", error.Message)
+                        Succ: _ => { /* Turn advancement logged by TurnManager */ },
+                        Fail: error => _logger.Warning("Failed to advance turn: {Error}", error.Message)
                     );
-                }
-                else
-                {
-                    _logger.Debug("Turn advancement not available (conditions not met)");
                 }
             }
             catch (System.Exception ex)

--- a/src/Features/Turn/Notifications/TurnAdvancementHandler.cs
+++ b/src/Features/Turn/Notifications/TurnAdvancementHandler.cs
@@ -4,23 +4,26 @@ using BlockLife.Core.Features.Turn.Commands;
 using LanguageExt;
 using MediatR;
 using Serilog;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace BlockLife.Core.Features.Turn.Notifications
 {
     /// <summary>
-    /// Handles block placement notifications by marking actions as performed in the turn system
-    /// and optionally advancing turns when conditions are met.
-    /// Following TDD+VSA Comprehensive Development Workflow.
+    /// DEPRECATED: This handler incorrectly advances turns on block placement.
+    /// Block placement (including cascades) should NOT consume turns.
+    /// Only explicit user moves should advance turns.
+    /// See TurnAdvancementAfterMoveHandler for correct implementation.
     /// </summary>
-    public class TurnAdvancementHandler : INotificationHandler<BlockPlacedNotification>
+    [Obsolete("Use TurnAdvancementAfterMoveHandler instead. Block placement should not advance turns.")]
+    public class TurnAdvancementHandler_DISABLED : INotificationHandler<BlockPlacedNotification>
     {
         private readonly ITurnManager _turnManager;
         private readonly IMediator _mediator;
         private readonly ILogger _logger;
 
-        public TurnAdvancementHandler(
+        public TurnAdvancementHandler_DISABLED(
             ITurnManager turnManager,
             IMediator mediator,
             ILogger logger)

--- a/src/Features/Turn/Notifications/TurnAdvancementHandler.cs
+++ b/src/Features/Turn/Notifications/TurnAdvancementHandler.cs
@@ -34,16 +34,17 @@ namespace BlockLife.Core.Features.Turn.Notifications
         {
             try
             {
-                _logger.Debug("Processing turn advancement after block placement at {Position}", notification.Position);
+                var currentTurn = _turnManager.GetTurnsElapsed();
+                _logger.Information("📍 BLOCK PLACED at {Position}, Turn {Turn} - checking turn advancement", 
+                    notification.Position, currentTurn);
 
                 // Step 1: Mark that an action has been performed this turn
                 _turnManager.MarkActionPerformed();
-                _logger.Debug("Marked action as performed for current turn");
 
                 // Step 2: Check if turn advancement is available and auto-advance
                 if (_turnManager.CanAdvanceTurn())
                 {
-                    _logger.Debug("Turn advancement is available, auto-advancing");
+                    _logger.Information("➡️ ADVANCING TURN after block placement");
                     
                     var command = AdvanceTurnCommand.Create();
                     var result = await _mediator.Send(command, cancellationToken);

--- a/src/Features/Turn/Notifications/TurnAdvancementHandler.cs
+++ b/src/Features/Turn/Notifications/TurnAdvancementHandler.cs
@@ -1,0 +1,69 @@
+using BlockLife.Core.Domain.Turn;
+using BlockLife.Core.Features.Block.Placement.Notifications;
+using BlockLife.Core.Features.Turn.Commands;
+using LanguageExt;
+using MediatR;
+using Serilog;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BlockLife.Core.Features.Turn.Notifications
+{
+    /// <summary>
+    /// Handles block placement notifications by marking actions as performed in the turn system
+    /// and optionally advancing turns when conditions are met.
+    /// Following TDD+VSA Comprehensive Development Workflow.
+    /// </summary>
+    public class TurnAdvancementHandler : INotificationHandler<BlockPlacedNotification>
+    {
+        private readonly ITurnManager _turnManager;
+        private readonly IMediator _mediator;
+        private readonly ILogger _logger;
+
+        public TurnAdvancementHandler(
+            ITurnManager turnManager,
+            IMediator mediator,
+            ILogger logger)
+        {
+            _turnManager = turnManager;
+            _mediator = mediator;
+            _logger = logger;
+        }
+
+        public async Task Handle(BlockPlacedNotification notification, CancellationToken cancellationToken)
+        {
+            try
+            {
+                _logger.Debug("Processing turn advancement after block placement at {Position}", notification.Position);
+
+                // Step 1: Mark that an action has been performed this turn
+                _turnManager.MarkActionPerformed();
+                _logger.Debug("Marked action as performed for current turn");
+
+                // Step 2: Check if turn advancement is available and auto-advance
+                if (_turnManager.CanAdvanceTurn())
+                {
+                    _logger.Debug("Turn advancement is available, auto-advancing");
+                    
+                    var command = AdvanceTurnCommand.Create();
+                    var result = await _mediator.Send(command, cancellationToken);
+                    
+                    result.Match(
+                        Succ: _ => _logger.Debug("Successfully auto-advanced turn after block placement"),
+                        Fail: error => _logger.Warning("Failed to auto-advance turn: {Error}", error.Message)
+                    );
+                }
+                else
+                {
+                    _logger.Debug("Turn advancement not available (conditions not met)");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Error processing turn advancement after block placement at {Position}: {ErrorMessage}", 
+                    notification.Position, ex.Message);
+                // Don't throw - turn advancement failure shouldn't break the block placement
+            }
+        }
+    }
+}

--- a/src/Features/Turn/Notifications/TurnAdvancementHandler.cs
+++ b/src/Features/Turn/Notifications/TurnAdvancementHandler.cs
@@ -17,7 +17,8 @@ namespace BlockLife.Core.Features.Turn.Notifications
     /// See TurnAdvancementAfterMoveHandler for correct implementation.
     /// </summary>
     [Obsolete("Use TurnAdvancementAfterMoveHandler instead. Block placement should not advance turns.")]
-    public class TurnAdvancementHandler_DISABLED : INotificationHandler<BlockPlacedNotification>
+    // DISABLED: Removed INotificationHandler interface to prevent MediatR registration
+    public class TurnAdvancementHandler_DISABLED // : INotificationHandler<BlockPlacedNotification>
     {
         private readonly ITurnManager _turnManager;
         private readonly IMediator _mediator;
@@ -33,6 +34,7 @@ namespace BlockLife.Core.Features.Turn.Notifications
             _logger = logger;
         }
 
+        /* DISABLED: Method commented out to prevent compilation and registration
         public async Task Handle(BlockPlacedNotification notification, CancellationToken cancellationToken)
         {
             try
@@ -69,5 +71,6 @@ namespace BlockLife.Core.Features.Turn.Notifications
                 // Don't throw - turn advancement failure shouldn't break the block placement
             }
         }
+        */
     }
 }

--- a/src/Features/Turn/Services/TurnManager.cs
+++ b/src/Features/Turn/Services/TurnManager.cs
@@ -1,0 +1,163 @@
+using BlockLife.Core.Domain.Turn;
+using LanguageExt;
+using LanguageExt.Common;
+using static LanguageExt.Prelude;
+using System.Threading;
+
+namespace BlockLife.Core.Features.Turn.Services
+{
+    /// <summary>
+    /// Domain service implementation for managing turn progression and state.
+    /// Enforces business rules: only one action per turn, turns advance after valid actions.
+    /// Thread-safe implementation using immutable Turn objects and atomic operations.
+    /// Following established service patterns with LanguageExt functional types.
+    /// </summary>
+    public sealed class TurnManager : ITurnManager
+    {
+        private Option<Core.Domain.Turn.Turn> _currentTurn = None;
+        private bool _actionPerformed = false;
+        private readonly object _lock = new object();
+
+        /// <summary>
+        /// Gets the current turn.
+        /// </summary>
+        /// <returns>The current turn, or None if not initialized</returns>
+        public Option<Core.Domain.Turn.Turn> GetCurrentTurn() => _currentTurn;
+
+        /// <summary>
+        /// Advances to the next turn with validation.
+        /// Requires that an action has been performed in the current turn.
+        /// Resets the action flag for the new turn.
+        /// </summary>
+        /// <returns>Fin&lt;Turn&gt; with new current turn or validation error</returns>
+        public Fin<Core.Domain.Turn.Turn> AdvanceTurn()
+        {
+            lock (_lock)
+            {
+                // Validate that we can advance
+                if (!CanAdvanceTurn())
+                {
+                    return _currentTurn.Match(
+                        Some: turn => FinFail<Core.Domain.Turn.Turn>(Error.New($"Cannot advance from turn {turn.Number} - no action performed")),
+                        None: () => FinFail<Core.Domain.Turn.Turn>(Error.New("Cannot advance turn - game not initialized"))
+                    );
+                }
+
+                return _currentTurn.Match(
+                    Some: current => 
+                    {
+                        return current.Next().Match(
+                            Succ: nextTurn =>
+                            {
+                                _currentTurn = Some(nextTurn);
+                                _actionPerformed = false; // Reset for new turn
+                                return nextTurn;
+                            },
+                            Fail: error => FinFail<Core.Domain.Turn.Turn>(error)
+                        );
+                    },
+                    None: () => FinFail<Core.Domain.Turn.Turn>(Error.New("Cannot advance turn - game not initialized"))
+                );
+            }
+        }
+
+        /// <summary>
+        /// Checks if turn advancement is currently allowed.
+        /// Turn advancement requires that a valid game action was completed.
+        /// </summary>
+        /// <returns>True if turn can be advanced, false otherwise</returns>
+        public bool CanAdvanceTurn()
+        {
+            return _currentTurn.IsSome && _actionPerformed;
+        }
+
+        /// <summary>
+        /// Resets the turn manager to initial state (turn 1).
+        /// Used when starting a new game.
+        /// </summary>
+        /// <returns>Fin&lt;Turn&gt; with initial turn</returns>
+        public Fin<Core.Domain.Turn.Turn> Reset()
+        {
+            lock (_lock)
+            {
+                var initialTurn = Core.Domain.Turn.Turn.CreateInitial();
+                _currentTurn = Some(initialTurn);
+                _actionPerformed = false;
+                return initialTurn;
+            }
+        }
+
+        /// <summary>
+        /// Gets the total number of turns elapsed in the current game.
+        /// </summary>
+        /// <returns>Number of turns completed (current turn number), 0 if not initialized</returns>
+        public int GetTurnsElapsed()
+        {
+            return _currentTurn.Match(
+                Some: turn => turn.Number,
+                None: () => 0
+            );
+        }
+
+        /// <summary>
+        /// Marks that a valid action has been performed, enabling turn advancement.
+        /// This is called after successful moves, pattern execution, etc.
+        /// Can only be called once per turn to enforce one-action-per-turn rule.
+        /// </summary>
+        public void MarkActionPerformed()
+        {
+            lock (_lock)
+            {
+                // Only allow one action per turn
+                if (!_actionPerformed)
+                {
+                    _actionPerformed = true;
+                }
+                // Note: Silently ignore if already performed to avoid exceptions
+                // in complex command chains
+            }
+        }
+
+        /// <summary>
+        /// Checks if an action has been performed in the current turn.
+        /// Used to enforce one-action-per-turn limitation.
+        /// </summary>
+        /// <returns>True if an action was performed this turn</returns>
+        public bool HasActionBeenPerformed() => _actionPerformed;
+
+        /// <summary>
+        /// Loads turn state from external source (save data, persistence layer).
+        /// Validates the turn and action state before setting internal state.
+        /// </summary>
+        /// <param name="turn">The turn to restore</param>
+        /// <param name="actionPerformed">Whether an action was performed in this turn</param>
+        /// <returns>Fin&lt;Turn&gt; with loaded turn or validation error</returns>
+        public Fin<Core.Domain.Turn.Turn> LoadState(Core.Domain.Turn.Turn turn, bool actionPerformed)
+        {
+            if (turn == null)
+                return FinFail<Core.Domain.Turn.Turn>(Error.New("Cannot load null turn"));
+
+            if (turn.Number < 1)
+                return FinFail<Core.Domain.Turn.Turn>(Error.New($"Invalid turn number: {turn.Number}"));
+
+            lock (_lock)
+            {
+                _currentTurn = Some(turn);
+                _actionPerformed = actionPerformed;
+                return turn;
+            }
+        }
+
+        /// <summary>
+        /// Gets a summary of the current turn state for debugging and logging.
+        /// </summary>
+        /// <returns>Human-readable turn state summary</returns>
+        public string GetTurnStateSummary()
+        {
+            return _currentTurn.Match(
+                Some: turn => $"Turn {turn.Number}, Action: {(_actionPerformed ? "Performed" : "Pending")}",
+                None: () => "Turn system not initialized"
+            );
+        }
+    }
+}

--- a/src/Features/Turn/Services/TurnManager.cs
+++ b/src/Features/Turn/Services/TurnManager.cs
@@ -51,7 +51,7 @@ namespace BlockLife.Core.Features.Turn.Services
                         return current.Next().Match(
                             Succ: nextTurn =>
                             {
-                                _logger.Information("🔄 TURN ADVANCING: Turn {CurrentTurn} → Turn {NextTurn}", 
+                                _logger.Information("Turn {CurrentTurn} → Turn {NextTurn}", 
                                     current.Number, nextTurn.Number);
                                 _currentTurn = Some(nextTurn);
                                 _actionPerformed = false; // Reset for new turn
@@ -116,14 +116,9 @@ namespace BlockLife.Core.Features.Turn.Services
                 if (!_actionPerformed)
                 {
                     _actionPerformed = true;
-                    var turnNum = _currentTurn.Match(Some: t => t.Number, None: () => 0);
-                    _logger.Debug("✓ ACTION MARKED for Turn {Turn}", turnNum);
+                    // Debug logging removed - action marking is internal implementation detail
                 }
-                else
-                {
-                    var turnNum = _currentTurn.Match(Some: t => t.Number, None: () => 0);
-                    _logger.Debug("⚠️ ACTION ALREADY MARKED for Turn {Turn} - ignoring duplicate", turnNum);
-                }
+                // Silently ignore if already performed - this is expected behavior
                 // Note: Silently ignore if already performed to avoid exceptions
                 // in complex command chains
             }

--- a/src/Features/Turn/TurnDisplayPresenter.cs
+++ b/src/Features/Turn/TurnDisplayPresenter.cs
@@ -1,0 +1,122 @@
+using BlockLife.Core.Features.Turn.Effects;
+using BlockLife.Core.Presentation;
+using MediatR;
+using Serilog;
+using System;
+using System.Threading.Tasks;
+
+namespace BlockLife.Core.Features.Turn
+{
+    /// <summary>
+    /// Presenter for the turn display view that handles turn state updates.
+    /// Coordinates between turn system notifications and view updates.
+    /// </summary>
+    public sealed class TurnDisplayPresenter : PresenterBase<ITurnDisplayView>
+    {
+        private readonly IMediator _mediator;
+        private readonly ILogger _logger;
+        private IDisposable? _turnStartSubscription;
+        private IDisposable? _turnEndSubscription;
+
+        public TurnDisplayPresenter(ITurnDisplayView view, IMediator mediator, ILogger logger)
+            : base(view)
+        {
+            _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Initializes the turn display presenter and subscribes to turn notifications.
+        /// Subscribes to domain notifications to keep the view in sync with turn changes.
+        /// </summary>
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            _logger.Information("TurnDisplayPresenter initialized, setting up turn display and notification subscriptions");
+
+            try
+            {
+                // Subscribe to domain notification events from the notification bridge using weak events
+                _turnStartSubscription = TurnNotificationBridge.SubscribeToTurnStart(OnTurnStartNotification);
+                _turnEndSubscription = TurnNotificationBridge.SubscribeToTurnEnd(OnTurnEndNotification);
+
+                _logger.Information("Subscribed to turn notification events using thread-safe weak events");
+
+                // Initialize view with turn 1 (default starting state)
+                var initialTurn = BlockLife.Core.Domain.Turn.Turn.CreateInitial();
+                View.UpdateCurrentTurn(initialTurn);
+
+                _logger.Information("Turn display initialized with initial turn");
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Error setting up turn display");
+            }
+        }
+
+        /// <summary>
+        /// Handles turn start notifications from the domain notification bridge.
+        /// Automatically updates the view when turns start.
+        /// </summary>
+        private Task OnTurnStartNotification(TurnStartNotification notification)
+        {
+            try
+            {
+                _logger.Debug("Received turn start notification for Turn {TurnNumber}",
+                    notification.Turn.Number);
+
+                View.DisplayTurnStart(notification.Turn);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Error handling turn start notification for Turn {TurnNumber}", 
+                    notification.Turn.Number);
+                
+                // Show error to user if view update fails
+                View.ShowTurnError($"Failed to update turn display: {ex.Message}");
+            }
+            
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Handles turn end notifications from the domain notification bridge.
+        /// Automatically updates the view when turns end.
+        /// </summary>
+        private Task OnTurnEndNotification(TurnEndNotification notification)
+        {
+            try
+            {
+                _logger.Debug("Received turn end notification for Turn {TurnNumber}",
+                    notification.Turn.Number);
+
+                View.DisplayTurnEnd(notification.Turn);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Error handling turn end notification for Turn {TurnNumber}", 
+                    notification.Turn.Number);
+                
+                // Show error to user if view update fails
+                View.ShowTurnError($"Failed to update turn display: {ex.Message}");
+            }
+            
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Disposes the presenter and unsubscribes from turn notifications to prevent memory leaks.
+        /// </summary>
+        public override void Dispose()
+        {
+            // Dispose weak event subscriptions to prevent memory leaks
+            _turnStartSubscription?.Dispose();
+            _turnEndSubscription?.Dispose();
+
+            _logger.Information("TurnDisplayPresenter disposed and weak event subscriptions cleaned up");
+
+            base.Dispose();
+        }
+    }
+}

--- a/tests/BlockLife.Core.Tests/Domain/Turn/TurnTests.cs
+++ b/tests/BlockLife.Core.Tests/Domain/Turn/TurnTests.cs
@@ -1,0 +1,239 @@
+using BlockLife.Core.Domain.Turn;
+using FluentAssertions;
+using LanguageExt;
+using static LanguageExt.Prelude;
+using System;
+using Xunit;
+
+namespace BlockLife.Core.Tests.Domain.Turn
+{
+    /// <summary>
+    /// Comprehensive tests for Turn domain value object.
+    /// Tests immutability, validation, business rules, and functional operations.
+    /// Part of VS_006 Phase 1 - Domain Model testing.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "Turn")]
+    [Trait("Layer", "Domain")]
+    public class TurnTests
+    {
+        [Fact]
+        public void Create_ValidNumber_ReturnsSuccessWithTurn()
+        {
+            // Arrange
+            const int turnNumber = 5;
+
+            // Act
+            var result = BlockLife.Core.Domain.Turn.Turn.Create(turnNumber);
+
+            // Assert
+            result.IsSucc.Should().BeTrue();
+            
+            var turn = result.IfFail(_ => throw new Exception("Should not fail"));
+            turn.Number.Should().Be(turnNumber);
+            turn.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(-100)]
+        public void Create_InvalidNumber_ReturnsFailure(int invalidNumber)
+        {
+            // Act
+            var result = BlockLife.Core.Domain.Turn.Turn.Create(invalidNumber);
+
+            // Assert
+            result.IsFail.Should().BeTrue();
+            result.IfFail(error => error.Message.Should().Contain("must be 1 or greater"));
+        }
+
+        [Fact]
+        public void Create_MinimumValidNumber_ReturnsSuccess()
+        {
+            // Act
+            var result = BlockLife.Core.Domain.Turn.Turn.Create(1);
+
+            // Assert
+            result.IsSucc.Should().BeTrue();
+            var turn = result.IfFail(_ => throw new Exception("Should not fail"));
+            turn.Number.Should().Be(1);
+        }
+
+        [Fact]
+        public void CreateInitial_Always_ReturnsTurnOne()
+        {
+            // Act
+            var turn = BlockLife.Core.Domain.Turn.Turn.CreateInitial();
+
+            // Assert
+            turn.Number.Should().Be(1);
+            turn.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+            turn.IsFirst.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Next_ValidTurn_ReturnsIncrementedTurn()
+        {
+            // Arrange
+            var turn = BlockLife.Core.Domain.Turn.Turn.CreateInitial();
+
+            // Act
+            var nextResult = turn.Next();
+
+            // Assert
+            nextResult.IsSucc.Should().BeTrue();
+            
+            var nextTurn = nextResult.IfFail(_ => throw new Exception("Should not fail"));
+            nextTurn.Number.Should().Be(2);
+            nextTurn.CreatedAt.Should().BeAfter(turn.CreatedAt);
+            nextTurn.IsFirst.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Next_MaxIntegerTurn_ReturnsFailure()
+        {
+            // Arrange - Create turn with max value (this is theoretical, but tests overflow protection)
+            var maxTurn = new BlockLife.Core.Domain.Turn.Turn
+            {
+                Number = int.MaxValue,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            // Act
+            var result = maxTurn.Next();
+
+            // Assert
+            result.IsFail.Should().BeTrue();
+            result.IfFail(error => error.Message.Should().Contain("overflow"));
+        }
+
+        [Theory]
+        [InlineData(1, 3, true)]
+        [InlineData(5, 5, false)]
+        [InlineData(10, 2, false)]
+        public void IsBefore_CompareTurns_ReturnsExpectedResult(int firstTurnNumber, int secondTurnNumber, bool expectedResult)
+        {
+            // Arrange
+            var firstTurn = BlockLife.Core.Domain.Turn.Turn.Create(firstTurnNumber).IfFail(_ => throw new Exception());
+            var secondTurn = BlockLife.Core.Domain.Turn.Turn.Create(secondTurnNumber).IfFail(_ => throw new Exception());
+
+            // Act
+            var result = firstTurn.IsBefore(secondTurn);
+
+            // Assert
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [InlineData(3, 1, true)]
+        [InlineData(5, 5, false)]
+        [InlineData(2, 10, false)]
+        public void IsAfter_CompareTurns_ReturnsExpectedResult(int firstTurnNumber, int secondTurnNumber, bool expectedResult)
+        {
+            // Arrange
+            var firstTurn = BlockLife.Core.Domain.Turn.Turn.Create(firstTurnNumber).IfFail(_ => throw new Exception());
+            var secondTurn = BlockLife.Core.Domain.Turn.Turn.Create(secondTurnNumber).IfFail(_ => throw new Exception());
+
+            // Act
+            var result = firstTurn.IsAfter(secondTurn);
+
+            // Assert
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [InlineData(1, true)]
+        [InlineData(2, false)]
+        [InlineData(100, false)]
+        public void IsFirst_VariousTurnNumbers_ReturnsExpectedResult(int turnNumber, bool expectedResult)
+        {
+            // Arrange
+            var turn = BlockLife.Core.Domain.Turn.Turn.Create(turnNumber).IfFail(_ => throw new Exception());
+
+            // Act & Assert
+            turn.IsFirst.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [InlineData(1, 5, 4)]
+        [InlineData(10, 3, 7)]
+        [InlineData(5, 5, 0)]
+        [InlineData(100, 200, 100)]
+        public void DistanceTo_VariousTurns_ReturnsAbsoluteDifference(int firstNumber, int secondNumber, int expectedDistance)
+        {
+            // Arrange
+            var firstTurn = BlockLife.Core.Domain.Turn.Turn.Create(firstNumber).IfFail(_ => throw new Exception());
+            var secondTurn = BlockLife.Core.Domain.Turn.Turn.Create(secondNumber).IfFail(_ => throw new Exception());
+
+            // Act
+            var distance = firstTurn.DistanceTo(secondTurn);
+
+            // Assert
+            distance.Should().Be(expectedDistance);
+        }
+
+        [Fact]
+        public void ToString_ValidTurn_ReturnsFormattedString()
+        {
+            // Arrange
+            var turn = BlockLife.Core.Domain.Turn.Turn.Create(42).IfFail(_ => throw new Exception());
+
+            // Act
+            var result = turn.ToString();
+
+            // Assert
+            result.Should().StartWith("Turn 42");
+            result.Should().Contain(turn.CreatedAt.ToString("yyyy-MM-dd HH:mm:ss"));
+        }
+
+        [Fact]
+        public void TurnEquality_SameTurnNumbers_AreEqual()
+        {
+            // Arrange
+            var turn1 = new BlockLife.Core.Domain.Turn.Turn { Number = 5, CreatedAt = DateTime.UtcNow };
+            var turn2 = new BlockLife.Core.Domain.Turn.Turn { Number = 5, CreatedAt = DateTime.UtcNow };
+
+            // Act & Assert - Records provide structural equality
+            turn1.Should().NotBeSameAs(turn2); // Different objects
+            turn1.Number.Should().Be(turn2.Number); // But same data
+        }
+
+        [Fact]
+        public void TurnImmutability_ModifyingCopyDoesNotAffectOriginal()
+        {
+            // Arrange
+            var originalTurn = BlockLife.Core.Domain.Turn.Turn.CreateInitial();
+
+            // Act - Create modified copy using with expression
+            var modifiedTurn = originalTurn with { Number = 99 };
+
+            // Assert
+            originalTurn.Number.Should().Be(1); // Original unchanged
+            modifiedTurn.Number.Should().Be(99); // Copy modified
+        }
+
+        [Fact]
+        public void ChainedNext_MultipleCalls_CreatesSequence()
+        {
+            // Arrange
+            var initialTurn = BlockLife.Core.Domain.Turn.Turn.CreateInitial();
+
+            // Act
+            var turn2 = initialTurn.Next().IfFail(_ => throw new Exception());
+            var turn3 = turn2.Next().IfFail(_ => throw new Exception());
+            var turn4 = turn3.Next().IfFail(_ => throw new Exception());
+
+            // Assert
+            initialTurn.Number.Should().Be(1);
+            turn2.Number.Should().Be(2);
+            turn3.Number.Should().Be(3);
+            turn4.Number.Should().Be(4);
+            
+            // Each turn should be created after the previous
+            turn2.CreatedAt.Should().BeOnOrAfter(initialTurn.CreatedAt);
+            turn3.CreatedAt.Should().BeOnOrAfter(turn2.CreatedAt);
+            turn4.CreatedAt.Should().BeOnOrAfter(turn3.CreatedAt);
+        }
+    }
+}

--- a/tests/BlockLife.Core.Tests/Features/Block/Drag/DragCommandTests.cs
+++ b/tests/BlockLife.Core.Tests/Features/Block/Drag/DragCommandTests.cs
@@ -57,6 +57,10 @@ namespace BlockLife.Core.Tests.Features.Block.Drag
             // Add move command handler (needed by CompleteDragCommandHandler)
             services.AddTransient<BlockLife.Core.Features.Block.Commands.MoveBlockCommandHandler>();
 
+            // Add turn manager (required by TurnAdvancementAfterMoveHandler)
+            services.AddSingleton<BlockLife.Core.Domain.Turn.ITurnManager, 
+                BlockLife.Core.Features.Turn.Services.TurnManager>();
+
             // Add simulation manager (required by some handlers)
             services.AddSingleton<BlockLife.Core.Application.Simulation.ISimulationManager,
                 BlockLife.Core.Application.Simulation.SimulationManager>();

--- a/tests/BlockLife.Core.Tests/Features/Turn/Commands/AdvanceTurnCommandHandlerTests.cs
+++ b/tests/BlockLife.Core.Tests/Features/Turn/Commands/AdvanceTurnCommandHandlerTests.cs
@@ -1,0 +1,266 @@
+using BlockLife.Core.Domain.Turn;
+using BlockLife.Core.Features.Turn.Commands;
+using BlockLife.Core.Features.Turn.Effects;
+using BlockLife.Core.Tests.Utils;
+using FluentAssertions;
+using LanguageExt;
+using LanguageExt.Common;
+using MediatR;
+using Moq;
+using Serilog;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace BlockLife.Core.Tests.Features.Turn.Commands
+{
+    /// <summary>
+    /// TDD Tests for AdvanceTurnCommandHandler - Following Comprehensive Development Workflow
+    /// These tests are written FIRST to drive the implementation (RED phase)
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "Turn")]
+    [Trait("Layer", "Commands")]
+    public class AdvanceTurnCommandHandlerTests
+    {
+        private readonly Mock<ITurnManager> _mockTurnManager;
+        private readonly Mock<IMediator> _mockMediator;
+        private readonly Mock<ILogger> _mockLogger;
+        private readonly AdvanceTurnCommandHandler _handler;
+
+        public AdvanceTurnCommandHandlerTests()
+        {
+            _mockTurnManager = new Mock<ITurnManager>();
+            _mockMediator = new Mock<IMediator>();
+            _mockLogger = new Mock<ILogger>();
+
+            _handler = new AdvanceTurnCommandHandler(
+                _mockTurnManager.Object,
+                _mockMediator.Object,
+                _mockLogger.Object
+            );
+        }
+
+        [Fact]
+        public async Task Handle_WhenTurnAdvancementSucceeds_ReturnsSuccessAndPublishesBothNotifications()
+        {
+            // Arrange
+            var currentTurn = new BlockLife.Core.Domain.Turn.Turn { Number = 1, CreatedAt = DateTime.UtcNow };
+            var newTurn = new BlockLife.Core.Domain.Turn.Turn { Number = 2, CreatedAt = DateTime.UtcNow };
+            var command = AdvanceTurnCommand.Create();
+
+            _mockTurnManager
+                .Setup(m => m.GetCurrentTurn())
+                .Returns(Some(currentTurn));
+            _mockTurnManager
+                .Setup(m => m.AdvanceTurn())
+                .Returns(FinSucc(newTurn));
+            _mockMediator
+                .Setup(m => m.Publish(It.IsAny<INotification>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            TurnEndNotification? capturedEndNotification = null;
+            TurnStartNotification? capturedStartNotification = null;
+            _mockMediator
+                .Setup(m => m.Publish(It.IsAny<TurnEndNotification>(), It.IsAny<CancellationToken>()))
+                .Callback<INotification, CancellationToken>((notification, _) =>
+                {
+                    capturedEndNotification = notification as TurnEndNotification;
+                })
+                .Returns(Task.CompletedTask);
+            _mockMediator
+                .Setup(m => m.Publish(It.IsAny<TurnStartNotification>(), It.IsAny<CancellationToken>()))
+                .Callback<INotification, CancellationToken>((notification, _) =>
+                {
+                    capturedStartNotification = notification as TurnStartNotification;
+                })
+                .Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert - Result
+            result.IsSucc.Should().BeTrue();
+
+            // Assert - TurnManager interactions
+            _mockTurnManager.Verify(m => m.GetCurrentTurn(), Times.Once);
+            _mockTurnManager.Verify(m => m.AdvanceTurn(), Times.Once);
+
+            // Assert - TurnEndNotification published
+            _mockMediator.Verify(m => m.Publish(
+                It.IsAny<TurnEndNotification>(),
+                It.IsAny<CancellationToken>()
+            ), Times.Once);
+            capturedEndNotification.Should().NotBeNull();
+            capturedEndNotification!.Turn.Number.Should().Be(1);
+
+            // Assert - TurnStartNotification published
+            _mockMediator.Verify(m => m.Publish(
+                It.IsAny<TurnStartNotification>(),
+                It.IsAny<CancellationToken>()
+            ), Times.Once);
+            capturedStartNotification.Should().NotBeNull();
+            capturedStartNotification!.Turn.Number.Should().Be(2);
+        }
+
+        [Fact]
+        public async Task Handle_WhenTurnNotInitialized_ReturnsFailureWithError()
+        {
+            // Arrange
+            var command = AdvanceTurnCommand.Create();
+
+            _mockTurnManager
+                .Setup(m => m.GetCurrentTurn())
+                .Returns(None);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert - Result
+            result.IsFail.Should().BeTrue();
+            result.Match(
+                Succ: _ => throw new Exception("Should not succeed"),
+                Fail: error => error.Message.Should().Be("TURN_NOT_INITIALIZED")
+            );
+
+            // Assert - TurnManager interactions
+            _mockTurnManager.Verify(m => m.GetCurrentTurn(), Times.Once);
+            _mockTurnManager.Verify(m => m.AdvanceTurn(), Times.Never);
+
+            // Assert - No notifications published
+            _mockMediator.Verify(m => m.Publish(
+                It.IsAny<INotification>(),
+                It.IsAny<CancellationToken>()
+            ), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_WhenAdvanceTurnFails_ReturnsFailureWithError()
+        {
+            // Arrange
+            var currentTurn = new BlockLife.Core.Domain.Turn.Turn { Number = 5, CreatedAt = DateTime.UtcNow };
+            var command = AdvanceTurnCommand.Create();
+            var expectedError = Error.New("CANNOT_ADVANCE", "No action performed this turn");
+
+            _mockTurnManager
+                .Setup(m => m.GetCurrentTurn())
+                .Returns(Some(currentTurn));
+            _mockTurnManager
+                .Setup(m => m.AdvanceTurn())
+                .Returns(FinFail<BlockLife.Core.Domain.Turn.Turn>(expectedError));
+            _mockMediator
+                .Setup(m => m.Publish(It.IsAny<TurnEndNotification>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert - Result
+            result.IsFail.Should().BeTrue();
+            result.Match(
+                Succ: _ => throw new Exception("Should not succeed"),
+                Fail: error => error.Message.Should().Be("CANNOT_ADVANCE")
+            );
+
+            // Assert - TurnManager interactions
+            _mockTurnManager.Verify(m => m.GetCurrentTurn(), Times.Once);
+            _mockTurnManager.Verify(m => m.AdvanceTurn(), Times.Once);
+
+            // Assert - TurnEndNotification published but not TurnStartNotification
+            _mockMediator.Verify(m => m.Publish(
+                It.IsAny<TurnEndNotification>(),
+                It.IsAny<CancellationToken>()
+            ), Times.Once);
+            _mockMediator.Verify(m => m.Publish(
+                It.IsAny<TurnStartNotification>(),
+                It.IsAny<CancellationToken>()
+            ), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_WhenTurnEndNotificationFails_ReturnsFailureWithError()
+        {
+            // Arrange
+            var currentTurn = new BlockLife.Core.Domain.Turn.Turn { Number = 3, CreatedAt = DateTime.UtcNow };
+            var command = AdvanceTurnCommand.Create();
+
+            _mockTurnManager
+                .Setup(m => m.GetCurrentTurn())
+                .Returns(Some(currentTurn));
+            _mockMediator
+                .Setup(m => m.Publish(It.IsAny<TurnEndNotification>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("Network error"));
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert - Result
+            result.IsFail.Should().BeTrue();
+            result.Match(
+                Succ: _ => throw new Exception("Should not succeed"),
+                Fail: error => error.Message.Should().Be("TURN_END_NOTIFICATION_FAILED")
+            );
+
+            // Assert - TurnManager interactions (advance should not be called if end notification fails)
+            _mockTurnManager.Verify(m => m.GetCurrentTurn(), Times.Once);
+            _mockTurnManager.Verify(m => m.AdvanceTurn(), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_WhenTurnStartNotificationFails_ReturnsFailureWithError()
+        {
+            // Arrange
+            var currentTurn = new BlockLife.Core.Domain.Turn.Turn { Number = 7, CreatedAt = DateTime.UtcNow };
+            var newTurn = new BlockLife.Core.Domain.Turn.Turn { Number = 8, CreatedAt = DateTime.UtcNow };
+            var command = AdvanceTurnCommand.Create();
+
+            _mockTurnManager
+                .Setup(m => m.GetCurrentTurn())
+                .Returns(Some(currentTurn));
+            _mockTurnManager
+                .Setup(m => m.AdvanceTurn())
+                .Returns(FinSucc(newTurn));
+            _mockMediator
+                .Setup(m => m.Publish(It.IsAny<TurnEndNotification>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            _mockMediator
+                .Setup(m => m.Publish(It.IsAny<TurnStartNotification>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("Service unavailable"));
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert - Result
+            result.IsFail.Should().BeTrue();
+            result.Match(
+                Succ: _ => throw new Exception("Should not succeed"),
+                Fail: error => error.Message.Should().Be("TURN_START_NOTIFICATION_FAILED")
+            );
+
+            // Assert - All operations up to the failure should have been called
+            _mockTurnManager.Verify(m => m.GetCurrentTurn(), Times.Once);
+            _mockTurnManager.Verify(m => m.AdvanceTurn(), Times.Once);
+            _mockMediator.Verify(m => m.Publish(
+                It.IsAny<TurnEndNotification>(),
+                It.IsAny<CancellationToken>()
+            ), Times.Once);
+            _mockMediator.Verify(m => m.Publish(
+                It.IsAny<TurnStartNotification>(),
+                It.IsAny<CancellationToken>()
+            ), Times.Once);
+        }
+
+        [Fact]
+        public void AdvanceTurnCommand_Create_ProducesValidCommand()
+        {
+            // Act
+            var command = AdvanceTurnCommand.Create();
+
+            // Assert
+            command.Should().NotBeNull();
+            command.Should().BeOfType<AdvanceTurnCommand>();
+        }
+    }
+}

--- a/tests/BlockLife.Core.Tests/Features/Turn/Notifications/TurnAdvancementHandlerTests.cs
+++ b/tests/BlockLife.Core.Tests/Features/Turn/Notifications/TurnAdvancementHandlerTests.cs
@@ -1,0 +1,249 @@
+using BlockLife.Core.Domain.Turn;
+using BlockLife.Core.Domain.Block;
+using BlockLife.Core.Domain.Common;
+using BlockLife.Core.Features.Block.Placement.Notifications;
+using BlockLife.Core.Features.Turn.Commands;
+using BlockLife.Core.Features.Turn.Notifications;
+using BlockLife.Core.Tests.Utils;
+using FluentAssertions;
+using LanguageExt;
+using LanguageExt.Common;
+using MediatR;
+using Moq;
+using Serilog;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace BlockLife.Core.Tests.Features.Turn.Notifications
+{
+    /// <summary>
+    /// TDD Tests for TurnAdvancementHandler - Following Comprehensive Development Workflow
+    /// Tests integration between block placement and turn system.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "Turn")]
+    [Trait("Layer", "Handlers")]
+    public class TurnAdvancementHandlerTests
+    {
+        private readonly Mock<ITurnManager> _mockTurnManager;
+        private readonly Mock<IMediator> _mockMediator;
+        private readonly Mock<ILogger> _mockLogger;
+        private readonly TurnAdvancementHandler _handler;
+
+        public TurnAdvancementHandlerTests()
+        {
+            _mockTurnManager = new Mock<ITurnManager>();
+            _mockMediator = new Mock<IMediator>();
+            _mockLogger = new Mock<ILogger>();
+
+            _handler = new TurnAdvancementHandler(
+                _mockTurnManager.Object,
+                _mockMediator.Object,
+                _mockLogger.Object
+            );
+        }
+
+        [Fact]
+        public async Task Handle_WhenBlockPlacedAndCanAdvanceTurn_MarksActionAndAdvancesTurn()
+        {
+            // Arrange
+            var blockPlacedNotification = new BlockPlacedNotification(
+                TestGuids.BlockA,
+                new Vector2Int(2, 3),
+                BlockType.Work,
+                1,
+                DateTime.UtcNow
+            );
+
+            _mockTurnManager
+                .Setup(m => m.CanAdvanceTurn())
+                .Returns(true);
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<AdvanceTurnCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(FinSucc(LanguageExt.Unit.Default));
+
+            AdvanceTurnCommand? capturedCommand = null;
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<AdvanceTurnCommand>(), It.IsAny<CancellationToken>()))
+                .Callback<IRequest<Fin<LanguageExt.Unit>>, CancellationToken>((command, _) =>
+                {
+                    capturedCommand = command as AdvanceTurnCommand;
+                })
+                .ReturnsAsync(FinSucc(LanguageExt.Unit.Default));
+
+            // Act
+            await _handler.Handle(blockPlacedNotification, CancellationToken.None);
+
+            // Assert - Action marked
+            _mockTurnManager.Verify(m => m.MarkActionPerformed(), Times.Once);
+
+            // Assert - Turn advancement checked and executed
+            _mockTurnManager.Verify(m => m.CanAdvanceTurn(), Times.Once);
+            _mockMediator.Verify(m => m.Send(
+                It.IsAny<AdvanceTurnCommand>(),
+                It.IsAny<CancellationToken>()
+            ), Times.Once);
+
+            capturedCommand.Should().NotBeNull();
+            capturedCommand.Should().BeOfType<AdvanceTurnCommand>();
+        }
+
+        [Fact]
+        public async Task Handle_WhenBlockPlacedButCannotAdvanceTurn_MarksActionButDoesNotAdvance()
+        {
+            // Arrange
+            var blockPlacedNotification = new BlockPlacedNotification(
+                TestGuids.BlockB,
+                new Vector2Int(1, 1),
+                BlockType.Study,
+                1,
+                DateTime.UtcNow
+            );
+
+            _mockTurnManager
+                .Setup(m => m.CanAdvanceTurn())
+                .Returns(false);
+
+            // Act
+            await _handler.Handle(blockPlacedNotification, CancellationToken.None);
+
+            // Assert - Action marked
+            _mockTurnManager.Verify(m => m.MarkActionPerformed(), Times.Once);
+
+            // Assert - Turn advancement checked but not executed
+            _mockTurnManager.Verify(m => m.CanAdvanceTurn(), Times.Once);
+            _mockMediator.Verify(m => m.Send(
+                It.IsAny<AdvanceTurnCommand>(),
+                It.IsAny<CancellationToken>()
+            ), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_WhenAdvanceTurnCommandFails_DoesNotThrowException()
+        {
+            // Arrange
+            var blockPlacedNotification = new BlockPlacedNotification(
+                TestGuids.BlockC,
+                new Vector2Int(4, 4),
+                BlockType.Health,
+                1,
+                DateTime.UtcNow
+            );
+
+            _mockTurnManager
+                .Setup(m => m.CanAdvanceTurn())
+                .Returns(true);
+            _mockMediator
+                .Setup(m => m.Send(It.IsAny<AdvanceTurnCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(FinFail<LanguageExt.Unit>(Error.New("ADVANCE_FAILED", "Turn advancement failed")));
+
+            // Act - Should not throw
+            Func<Task> act = async () => await _handler.Handle(blockPlacedNotification, CancellationToken.None);
+
+            // Assert - No exception thrown
+            await act.Should().NotThrowAsync();
+
+            // Assert - All expected interactions occurred
+            _mockTurnManager.Verify(m => m.MarkActionPerformed(), Times.Once);
+            _mockTurnManager.Verify(m => m.CanAdvanceTurn(), Times.Once);
+            _mockMediator.Verify(m => m.Send(
+                It.IsAny<AdvanceTurnCommand>(),
+                It.IsAny<CancellationToken>()
+            ), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_MultipleBlockPlacements_MarksActionEachTime()
+        {
+            // Arrange
+            var notification1 = new BlockPlacedNotification(
+                TestGuids.BlockA,
+                new Vector2Int(1, 1),
+                BlockType.Work,
+                1,
+                DateTime.UtcNow
+            );
+            var notification2 = new BlockPlacedNotification(
+                TestGuids.BlockB,
+                new Vector2Int(2, 2),
+                BlockType.Fun,
+                1,
+                DateTime.UtcNow
+            );
+
+            _mockTurnManager
+                .Setup(m => m.CanAdvanceTurn())
+                .Returns(false); // Prevent turn advancement for clarity
+
+            // Act
+            await _handler.Handle(notification1, CancellationToken.None);
+            await _handler.Handle(notification2, CancellationToken.None);
+
+            // Assert - Action marked for each placement
+            _mockTurnManager.Verify(m => m.MarkActionPerformed(), Times.Exactly(2));
+            _mockTurnManager.Verify(m => m.CanAdvanceTurn(), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task Handle_WhenTurnManagerThrows_DoesNotPropagatException()
+        {
+            // Arrange
+            var blockPlacedNotification = new BlockPlacedNotification(
+                TestGuids.BlockD,
+                new Vector2Int(0, 0),
+                BlockType.Relationship,
+                1,
+                DateTime.UtcNow
+            );
+
+            _mockTurnManager
+                .Setup(m => m.MarkActionPerformed())
+                .Throws(new InvalidOperationException("Turn manager error"));
+
+            // Act - Should not throw
+            Func<Task> act = async () => await _handler.Handle(blockPlacedNotification, CancellationToken.None);
+
+            // Assert - No exception propagated (logged instead)
+            await act.Should().NotThrowAsync();
+
+            // Assert - MarkActionPerformed was attempted
+            _mockTurnManager.Verify(m => m.MarkActionPerformed(), Times.Once);
+            // CanAdvanceTurn should not be called if MarkActionPerformed throws
+            _mockTurnManager.Verify(m => m.CanAdvanceTurn(), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_WhenCanAdvanceTurnThrows_ContinuesGracefully()
+        {
+            // Arrange
+            var blockPlacedNotification = new BlockPlacedNotification(
+                TestGuids.BlockE,
+                new Vector2Int(3, 3),
+                BlockType.CareerOpportunity,
+                2,
+                DateTime.UtcNow
+            );
+
+            _mockTurnManager
+                .Setup(m => m.CanAdvanceTurn())
+                .Throws(new InvalidOperationException("Cannot check turn advancement"));
+
+            // Act - Should not throw
+            Func<Task> act = async () => await _handler.Handle(blockPlacedNotification, CancellationToken.None);
+
+            // Assert - No exception propagated
+            await act.Should().NotThrowAsync();
+
+            // Assert - Action was marked before the exception
+            _mockTurnManager.Verify(m => m.MarkActionPerformed(), Times.Once);
+            _mockTurnManager.Verify(m => m.CanAdvanceTurn(), Times.Once);
+            _mockMediator.Verify(m => m.Send(
+                It.IsAny<AdvanceTurnCommand>(),
+                It.IsAny<CancellationToken>()
+            ), Times.Never);
+        }
+    }
+}

--- a/tests/BlockLife.Core.Tests/Features/Turn/Services/TurnManagerTests.cs
+++ b/tests/BlockLife.Core.Tests/Features/Turn/Services/TurnManagerTests.cs
@@ -1,0 +1,408 @@
+using BlockLife.Core.Domain.Turn;
+using BlockLife.Core.Features.Turn.Services;
+using FluentAssertions;
+using LanguageExt;
+using static LanguageExt.Prelude;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace BlockLife.Core.Tests.Features.Turn.Services
+{
+    /// <summary>
+    /// Comprehensive tests for TurnManager service implementation.
+    /// Tests business rules, state management, thread safety, and error conditions.
+    /// Part of VS_006 Phase 1 - Domain Model testing.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "Turn")]
+    [Trait("Layer", "Services")]
+    public class TurnManagerTests
+    {
+        [Fact]
+        public void GetCurrentTurn_NotInitialized_ReturnsNone()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+
+            // Act
+            var result = turnManager.GetCurrentTurn();
+
+            // Assert
+            result.IsNone.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Reset_Always_InitializesToTurnOne()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+
+            // Act
+            var result = turnManager.Reset();
+
+            // Assert
+            result.IsSucc.Should().BeTrue();
+            
+            var turn = result.IfFail(_ => throw new Exception("Should not fail"));
+            turn.Number.Should().Be(1);
+            turn.IsFirst.Should().BeTrue();
+            
+            // Verify current turn is set
+            var currentTurn = turnManager.GetCurrentTurn();
+            currentTurn.IsSome.Should().BeTrue();
+            currentTurn.IfNone(() => throw new Exception()).Number.Should().Be(1);
+        }
+
+        [Fact]
+        public void GetTurnsElapsed_NotInitialized_ReturnsZero()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+
+            // Act
+            var elapsed = turnManager.GetTurnsElapsed();
+
+            // Assert
+            elapsed.Should().Be(0);
+        }
+
+        [Fact]
+        public void GetTurnsElapsed_AfterReset_ReturnsOne()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            turnManager.Reset();
+
+            // Act
+            var elapsed = turnManager.GetTurnsElapsed();
+
+            // Assert
+            elapsed.Should().Be(1);
+        }
+
+        [Fact]
+        public void HasActionBeenPerformed_InitialState_ReturnsFalse()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            turnManager.Reset();
+
+            // Act
+            var hasAction = turnManager.HasActionBeenPerformed();
+
+            // Assert
+            hasAction.Should().BeFalse();
+        }
+
+        [Fact]
+        public void MarkActionPerformed_FirstTime_SetsFlag()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            turnManager.Reset();
+
+            // Act
+            turnManager.MarkActionPerformed();
+
+            // Assert
+            turnManager.HasActionBeenPerformed().Should().BeTrue();
+        }
+
+        [Fact]
+        public void MarkActionPerformed_MultipleCallsSameTurn_RemainsTrue()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            turnManager.Reset();
+
+            // Act
+            turnManager.MarkActionPerformed();
+            turnManager.MarkActionPerformed(); // Should not cause error
+            turnManager.MarkActionPerformed();
+
+            // Assert
+            turnManager.HasActionBeenPerformed().Should().BeTrue();
+        }
+
+        [Fact]
+        public void CanAdvanceTurn_NoActionPerformed_ReturnsFalse()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            turnManager.Reset();
+
+            // Act
+            var canAdvance = turnManager.CanAdvanceTurn();
+
+            // Assert
+            canAdvance.Should().BeFalse();
+        }
+
+        [Fact]
+        public void CanAdvanceTurn_ActionPerformed_ReturnsTrue()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            turnManager.Reset();
+            turnManager.MarkActionPerformed();
+
+            // Act
+            var canAdvance = turnManager.CanAdvanceTurn();
+
+            // Assert
+            canAdvance.Should().BeTrue();
+        }
+
+        [Fact]
+        public void CanAdvanceTurn_NotInitialized_ReturnsFalse()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+
+            // Act
+            var canAdvance = turnManager.CanAdvanceTurn();
+
+            // Assert
+            canAdvance.Should().BeFalse();
+        }
+
+        [Fact]
+        public void AdvanceTurn_NoActionPerformed_ReturnsFail()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            turnManager.Reset();
+
+            // Act
+            var result = turnManager.AdvanceTurn();
+
+            // Assert
+            result.IsFail.Should().BeTrue();
+            result.IfFail(error => error.Message.Should().Contain("no action performed"));
+        }
+
+        [Fact]
+        public void AdvanceTurn_NotInitialized_ReturnsFail()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+
+            // Act
+            var result = turnManager.AdvanceTurn();
+
+            // Assert
+            result.IsFail.Should().BeTrue();
+            result.IfFail(error => error.Message.Should().Contain("not initialized"));
+        }
+
+        [Fact]
+        public void AdvanceTurn_ValidConditions_AdvancesToNextTurn()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            turnManager.Reset();
+            turnManager.MarkActionPerformed();
+
+            // Act
+            var result = turnManager.AdvanceTurn();
+
+            // Assert
+            result.IsSucc.Should().BeTrue();
+            
+            var newTurn = result.IfFail(_ => throw new Exception("Should not fail"));
+            newTurn.Number.Should().Be(2);
+            
+            // Current turn should be updated
+            var currentTurn = turnManager.GetCurrentTurn().IfNone(() => throw new Exception());
+            currentTurn.Number.Should().Be(2);
+            
+            // Turns elapsed should be incremented
+            turnManager.GetTurnsElapsed().Should().Be(2);
+        }
+
+        [Fact]
+        public void AdvanceTurn_ValidConditions_ResetsActionFlag()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            turnManager.Reset();
+            turnManager.MarkActionPerformed();
+
+            // Act
+            turnManager.AdvanceTurn();
+
+            // Assert
+            turnManager.HasActionBeenPerformed().Should().BeFalse();
+            turnManager.CanAdvanceTurn().Should().BeFalse(); // Can't advance again without new action
+        }
+
+        [Fact]
+        public void FullTurnCycle_MultipleAdvances_WorksCorrectly()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            turnManager.Reset();
+
+            // Act & Assert - Turn 1 -> 2
+            turnManager.MarkActionPerformed();
+            var turn2Result = turnManager.AdvanceTurn();
+            turn2Result.IsSucc.Should().BeTrue();
+            turnManager.GetTurnsElapsed().Should().Be(2);
+            turnManager.HasActionBeenPerformed().Should().BeFalse();
+
+            // Act & Assert - Turn 2 -> 3  
+            turnManager.MarkActionPerformed();
+            var turn3Result = turnManager.AdvanceTurn();
+            turn3Result.IsSucc.Should().BeTrue();
+            turnManager.GetTurnsElapsed().Should().Be(3);
+            turnManager.HasActionBeenPerformed().Should().BeFalse();
+
+            // Act & Assert - Turn 3 -> 4
+            turnManager.MarkActionPerformed();
+            var turn4Result = turnManager.AdvanceTurn();
+            turn4Result.IsSucc.Should().BeTrue();
+            turnManager.GetTurnsElapsed().Should().Be(4);
+        }
+
+        [Fact]
+        public void LoadState_ValidTurn_LoadesSuccessfully()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            var turnToLoad = BlockLife.Core.Domain.Turn.Turn.Create(10).IfFail(_ => throw new Exception());
+
+            // Act
+            var result = turnManager.LoadState(turnToLoad, actionPerformed: true);
+
+            // Assert
+            result.IsSucc.Should().BeTrue();
+            result.IfFail(_ => throw new Exception()).Number.Should().Be(10);
+            
+            turnManager.GetCurrentTurn().IfNone(() => throw new Exception()).Number.Should().Be(10);
+            turnManager.HasActionBeenPerformed().Should().BeTrue();
+            turnManager.GetTurnsElapsed().Should().Be(10);
+        }
+
+        [Fact]
+        public void LoadState_NullTurn_ReturnsFail()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+
+            // Act
+            var result = turnManager.LoadState(null!, actionPerformed: false);
+
+            // Assert
+            result.IsFail.Should().BeTrue();
+            result.IfFail(error => error.Message.Should().Contain("null turn"));
+        }
+
+        [Fact]
+        public void LoadState_InvalidTurnNumber_ReturnsFail()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            var invalidTurn = new BlockLife.Core.Domain.Turn.Turn { Number = -5, CreatedAt = DateTime.UtcNow };
+
+            // Act  
+            var result = turnManager.LoadState(invalidTurn, actionPerformed: false);
+
+            // Assert
+            result.IsFail.Should().BeTrue();
+            result.IfFail(error => error.Message.Should().Contain("Invalid turn number"));
+        }
+
+        [Fact]
+        public void GetTurnStateSummary_InitializedWithAction_ReturnsCorrectSummary()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            turnManager.Reset();
+            turnManager.MarkActionPerformed();
+
+            // Act
+            var summary = turnManager.GetTurnStateSummary();
+
+            // Assert
+            summary.Should().Contain("Turn 1");
+            summary.Should().Contain("Action: Performed");
+        }
+
+        [Fact]
+        public void GetTurnStateSummary_InitializedWithoutAction_ReturnsCorrectSummary()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            turnManager.Reset();
+
+            // Act
+            var summary = turnManager.GetTurnStateSummary();
+
+            // Assert
+            summary.Should().Contain("Turn 1");
+            summary.Should().Contain("Action: Pending");
+        }
+
+        [Fact]
+        public void GetTurnStateSummary_NotInitialized_ReturnsNotInitializedMessage()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+
+            // Act
+            var summary = turnManager.GetTurnStateSummary();
+
+            // Assert
+            summary.Should().Contain("not initialized");
+        }
+
+        [Fact]
+        public void ThreadSafety_ConcurrentOperations_DoNotCorruptState()
+        {
+            // Arrange
+            var turnManager = new TurnManager();
+            turnManager.Reset();
+
+            // Act - Simulate concurrent operations
+            Parallel.For(0, 100, i =>
+            {
+                turnManager.MarkActionPerformed();
+                var canAdvance = turnManager.CanAdvanceTurn();
+                var currentTurn = turnManager.GetCurrentTurn();
+                var elapsed = turnManager.GetTurnsElapsed();
+            });
+
+            // Assert - State should remain consistent
+            turnManager.GetCurrentTurn().IsSome.Should().BeTrue();
+            turnManager.HasActionBeenPerformed().Should().BeTrue();
+            turnManager.GetTurnsElapsed().Should().Be(1); // Should still be on turn 1
+        }
+
+        [Fact]
+        public void BusinessRule_OneActionPerTurn_EnforcedCorrectly()
+        {
+            // Arrange  
+            var turnManager = new TurnManager();
+            turnManager.Reset();
+
+            // Act & Assert - Turn 1: Action -> Advance
+            turnManager.HasActionBeenPerformed().Should().BeFalse();
+            turnManager.CanAdvanceTurn().Should().BeFalse();
+            
+            turnManager.MarkActionPerformed();
+            turnManager.HasActionBeenPerformed().Should().BeTrue();
+            turnManager.CanAdvanceTurn().Should().BeTrue();
+            
+            var advanceResult = turnManager.AdvanceTurn();
+            advanceResult.IsSucc.Should().BeTrue();
+            
+            // Turn 2: No action yet -> Cannot advance  
+            turnManager.HasActionBeenPerformed().Should().BeFalse();
+            turnManager.CanAdvanceTurn().Should().BeFalse();
+            
+            var prematureAdvance = turnManager.AdvanceTurn();
+            prematureAdvance.IsFail.Should().BeTrue();
+        }
+    }
+}

--- a/tests/BlockLife.Core.Tests/Performance/FirstMoveDelayRegressionTest.cs
+++ b/tests/BlockLife.Core.Tests/Performance/FirstMoveDelayRegressionTest.cs
@@ -67,6 +67,10 @@ public class FirstMoveDelayRegressionTest : IDisposable
         services.AddTransient<BlockLife.Core.Features.Block.Placement.Rules.IBlockExistsRule,
             BlockLife.Core.Features.Block.Placement.Rules.BlockExistsRule>();
 
+        // Add turn manager (required by TurnAdvancementAfterMoveHandler)
+        services.AddSingleton<BlockLife.Core.Domain.Turn.ITurnManager, 
+            BlockLife.Core.Features.Turn.Services.TurnManager>();
+
         _serviceProvider = services.BuildServiceProvider();
         _mediator = _serviceProvider.GetRequiredService<IMediator>();
         _gridStateService = _serviceProvider.GetRequiredService<IGridStateService>();

--- a/tests/Features/Block/Drag/DragRangeValidationTests.cs
+++ b/tests/Features/Block/Drag/DragRangeValidationTests.cs
@@ -49,6 +49,10 @@ namespace BlockLife.Core.Tests.Features.Block.Drag
             services.AddSingleton<IBlockRepository>(p => p.GetRequiredService<GridStateService>());
             services.AddSingleton<IDragStateService, DragStateService>();
 
+            // Add turn manager (required by TurnAdvancementAfterMoveHandler)
+            services.AddSingleton<BlockLife.Core.Domain.Turn.ITurnManager, 
+                BlockLife.Core.Features.Turn.Services.TurnManager>();
+
             _serviceProvider = services.BuildServiceProvider();
             _mediator = _serviceProvider.GetRequiredService<IMediator>();
             _gridStateService = _serviceProvider.GetRequiredService<IGridStateService>();


### PR DESCRIPTION
## Summary
✅ **VS_006 Complete** - Turn system now works correctly with critical bug fix
- Fixed: Block placement was incorrectly advancing turns
- Only block MOVEMENT now consumes turns (as designed)
- Block PLACEMENT is free - no turn consumed
- Cascades and merges don't consume turns

## Critical Bug Fixed
The turn system had a fundamental game economy bug where ALL block placements (including cascades) were consuming turns. This made the game unplayable as cascades would eat up multiple turns.

### Before (❌ Wrong)
- User places block → Turn advances
- Cascade places block → Turn advances  
- Merge creates block → Turn advances

### After (✅ Correct)
- User places block → NO turn change (strategic positioning is free)
- User moves block → Turn advances (corrections cost turns)
- Cascades/merges → NO turn change (system reactions are free)

## Technical Changes
1. **Disabled incorrect handler**: `TurnAdvancementHandler` that listened to `BlockPlacedNotification`
2. **Created correct handler**: `TurnAdvancementAfterMoveHandler` that only responds to `BlockMovedNotification`
3. **Fixed test DI containers**: Added missing `ITurnManager` dependency to test setups
4. **Cleaned up logging**: Production-ready logging, removed debug clutter

## Testing
- ✅ All 450+ unit tests passing
- ✅ Architecture tests passing
- ✅ Manually verified in Godot:
  - Placing blocks doesn't advance turns
  - Moving blocks advances turns (Turn X → Turn Y logs)
  - Cascades process without consuming turns

## Game Design Impact
This fix restores the intended strategic depth:
- Players can take time to place blocks carefully (free action)
- Fixing placement mistakes costs valuable turns (meaningful choice)
- Good placement creates cascades without penalty (skill reward)

## Related Work
- Completes VS_006 Turn System implementation
- Enables VS_007 Auto-Spawn (blocks per turn) to proceed
- Enables VS_008 Resource Rewards to proceed

🤖 Generated with [Claude Code](https://claude.ai/code)